### PR TITLE
Modify find command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -128,7 +128,9 @@ Format: `find [n/NAME] [s/SCHOOL] [y/YEAR] [sb/SUBJECT]`
 Examples:
 * `find n/Alex david` matches `Alex David`, `alex david` and `Alex david`.
 * `find s/yishun` matches `Yishun Secondary School` and `Yishun Town Secondary School`.
-* `find n/alex s/yishun` searches for all students who match `n/alex` and `s/yishun`.
+* `find y/sec 3` matches `pri 3`, `Secondary 3` and `3`.
+* `find n/alex s/yishun y/sec 3` searches for all students who match all of `n/alex`, `s/yishun` and `y/sec 3`.
+* '
 
 ### Deleting a student : `delete`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -115,22 +115,27 @@ Examples:
 (written by: Ying Gao)
 Finds students who satisfy the given search criteria.
 
-Format: `find [n/NAME] [s/SCHOOL] [y/YEAR] [sb/SUBJECT]`
+Format: `find [n/NAME] [s/SCHOOL] [y/YEAR]`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * At least one of the optional fields must be provided.
 * The order of the optional fields do not matter. e.g `n/Hans s/River Valley` will match `s/River Valley n/Hans`
-* Only full words will be matched. e.g `han` will not match `hans`
-* Students whose name, school, year or subject contain the keywords given for their respective fields will be returned.
-* Only students satisfying all search criteria will be returned (i.e `AND` search).
+* Only full words will be matched. e.g `han` will not match `hans`.
+* For the name, students with a name that matches any whole keyword specified for the name will be considered to match for the name.
+* For the school, students with a school that contains any keyword specified for the school will be considered to match for the school.
+* For the year, students with a year that contains any keywords specified for the year will be considered to match for the year.
+* Only students matching all criteria specified will be returned (i.e `AND` search).
 
 (written by: Choon Siong)
 Examples:
 * `find n/Alex david` matches `Alex David`, `alex david` and `Alex david`.
-* `find s/yishun` matches `Yishun Secondary School` and `Yishun Town Secondary School`.
-* `find y/sec 3` matches `pri 3`, `Secondary 3` and `3`.
+* `find n/Alex david` does not match `Alexis Davinder`.
+* `find s/yishun sec` matches `Yishun Secondary School` and `Yishun Town Secondary School`.
+* `find s/yishun secondary` does not match `Yishun Sec`
+* `find y/sec 3` matches `sec 3`, `Secondary 3`
+* `find y/sec 3` matches `sec 4`
 * `find n/alex s/yishun y/sec 3` searches for all students who match all of `n/alex`, `s/yishun` and `y/sec 3`.
-* '
+* 
 
 ### Deleting a student : `delete`
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -14,6 +14,35 @@ public class StringUtil {
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
+     *   Ignores case and doesn't require a full word match.
+     *   <br>examples:<pre>
+     *       containsIgnoreCase("ABc def", "abc") == true
+     *       containsIgnoreCase("ABc def", "DEF") == true
+     *       containsIgnoreCase("ABc def", "AB") == true
+     *       </pre>
+     * @param sentence cannot be null
+     * @param word cannot be null, cannot be empty, must be a single word
+     */
+    public static boolean containsIgnoreCase(String sentence, String word) {
+        requireNonNull(sentence);
+        requireNonNull(word);
+
+        String preppedWord = word.trim().toLowerCase();
+        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
+        checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
+
+        String preppedSentence = sentence.toLowerCase();
+        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
+        if (wordsInPreppedSentence.length == 0 || preppedSentence.equals("")) {
+            return false;
+        }
+
+        return Arrays.stream(wordsInPreppedSentence)
+                .anyMatch(sentenceWord -> sentenceWord.contains(preppedWord));
+    }
+
+    /**
+     * Returns true if the {@code sentence} contains the {@code word}.
      *   Ignores case, but a full word match is required.
      *   <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,33 +2,51 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.Model;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.SchoolContainsKeywordsPredicate;
+import seedu.address.model.student.Student;
+import seedu.address.model.student.YearMatchPredicate;
+
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in Reeve by a certain criteria.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Given a non-empty list of filter criteria, "
+            + "finds all persons whose fields match or contain keywords (if applicable, case-insensitive) "
+            + "of each of the filter criteria and displays them as a list with index numbers.\n"
+            + "Parameters: [n/NAME] [s/SCHOOL] [y/YEAR]\n"
+            + "Example: " + COMMAND_WORD + " n/Alex david s/yishun";
 
-    private final NameContainsKeywordsPredicate predicate;
+    public static final String FIELD_NOT_GIVEN = "At least one field to search by must be provided.";
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+
+    private final List<Predicate<Student>> predicates;
+
+    /**
+     * @param predicates List of predicates that we use to filter Reeve with
+     */
+    public FindCommand(List<Predicate<Student>> predicates) {
+        assert predicates.size() > 0;
+        this.predicates = predicates;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        predicates.forEach(model::updateFilteredPersonList); // update model for each predicate
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -37,6 +55,92 @@ public class FindCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && predicates.equals(((FindCommand) other).predicates)); // state check
+    }
+
+    /**
+     * Stores the details to find the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class FindStudentDescriptor {
+        private NameContainsKeywordsPredicate namePredicate;
+        private SchoolContainsKeywordsPredicate schoolPredicate;
+        private YearMatchPredicate yearPredicate;
+
+
+        public FindStudentDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public FindStudentDescriptor(FindCommand.FindStudentDescriptor toCopy) {
+            setNamePredicate(toCopy.namePredicate);
+            setSchoolPredicate(toCopy.schoolPredicate);
+            setYearPredicate(toCopy.yearPredicate);
+        }
+
+        /**
+         * Returns true if at least one predicate is present.
+         */
+        public boolean isAnyPredicatePresent() {
+            return CollectionUtil.isAnyNonNull(namePredicate, schoolPredicate, yearPredicate);
+        }
+
+        /**
+         * Returns list of available predicates
+         */
+        public List<Predicate<Student>> getPredicates() {
+            assert isAnyPredicatePresent();
+            List<Predicate<Student>> predicates = new ArrayList<>();
+            getNamePredicate().ifPresent(predicates::add);
+            getSchoolPredicate().ifPresent(predicates::add);
+            getYearPredicate().ifPresent(predicates::add);
+            return predicates;
+        }
+
+        public Optional<NameContainsKeywordsPredicate> getNamePredicate() {
+            return Optional.ofNullable(namePredicate);
+        }
+
+        public void setNamePredicate(NameContainsKeywordsPredicate namePredicate) {
+            this.namePredicate = namePredicate;
+        }
+
+        public Optional<SchoolContainsKeywordsPredicate> getSchoolPredicate() {
+            return Optional.ofNullable(schoolPredicate);
+        }
+
+        public void setSchoolPredicate(SchoolContainsKeywordsPredicate schoolPredicate) {
+            this.schoolPredicate = schoolPredicate;
+        }
+
+        public Optional<YearMatchPredicate> getYearPredicate() {
+            return Optional.ofNullable(yearPredicate);
+        }
+
+        public void setYearPredicate(YearMatchPredicate yearPredicate) {
+            this.yearPredicate = yearPredicate;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof FindCommand.FindStudentDescriptor)) {
+                return false;
+            }
+
+            // state check
+            FindCommand.FindStudentDescriptor e = (FindCommand.FindStudentDescriptor) other;
+
+            return getNamePredicate().equals(e.getNamePredicate())
+                    && getSchoolPredicate().equals(e.getSchoolPredicate())
+                    && getYearPredicate().equals(e.getYearPredicate());
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -59,8 +59,8 @@ public class FindCommand extends Command {
     }
 
     /**
-     * Stores the details to find the person with. Each non-empty field value will replace the
-     * corresponding field value of the person.
+     * Stores the details to find students with. Each non-empty field will be used to
+     * filter the list of students in Reeve.
      */
     public static class FindStudentDescriptor {
         private NameContainsKeywordsPredicate namePredicate;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -42,6 +42,7 @@ public class AddressBookParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public class ArgumentMultimap {
 
     /** Prefixes mapped to their respective arguments**/
-    private final Map<Prefix, List<String>> argMultimap = new HashMap<>();
+    public final Map<Prefix, List<String>> argMultimap = new HashMap<>();
 
     /**
      * Associates the specified argument value with {@code prefix} key in this map.

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public class ArgumentMultimap {
 
     /** Prefixes mapped to their respective arguments**/
-    public final Map<Prefix, List<String>> argMultimap = new HashMap<>();
+    private final Map<Prefix, List<String>> argMultimap = new HashMap<>();
 
     /**
      * Associates the specified argument value with {@code prefix} key in this map.

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -16,4 +16,6 @@ public class CliSyntax {
     public static final Prefix[] COMPULSORY_PREFIXES = new Prefix[] {PREFIX_NAME, PREFIX_PHONE,
         PREFIX_SCHOOL, PREFIX_YEAR};
 
+    public static final Prefix[] FIND_SUPPORTED_PREFIXES =
+            new Prefix[] {PREFIX_NAME, PREFIX_SCHOOL, PREFIX_YEAR};
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -19,6 +19,9 @@ public class CliSyntax {
     public static final Prefix[] COMPULSORY_PREFIXES =
             new Prefix[] {PREFIX_NAME, PREFIX_PHONE, PREFIX_SCHOOL, PREFIX_YEAR};
 
+    public static final Prefix[] FIND_SUPPORTED_PREFIXES =
+            new Prefix[] {PREFIX_NAME, PREFIX_SCHOOL, PREFIX_YEAR};
+
     /**
      * Returns a list of all CLI syntax definitions.
      */
@@ -27,7 +30,4 @@ public class CliSyntax {
             PREFIX_YEAR, PREFIX_VENUE, PREFIX_TIME, PREFIX_DETAILS,
             PREFIX_FEE, PREFIX_PAYMENT};
     }
-
-    public static final Prefix[] FIND_SUPPORTED_PREFIXES =
-            new Prefix[] {PREFIX_NAME, PREFIX_SCHOOL, PREFIX_YEAR};
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -15,7 +15,6 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.SchoolContainsKeywordsPredicate;
-import seedu.address.model.student.Year;
 import seedu.address.model.student.YearMatchPredicate;
 
 /**
@@ -54,8 +53,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
         if (argMultimap.getValue(PREFIX_YEAR).isPresent()) {
             String year = argMultimap.getValue(PREFIX_YEAR).get();
-            Year parsedYear = ParserUtil.parseYear(year);
-            findStudentDescriptor.setYearPredicate(new YearMatchPredicate(parsedYear));
+            String[] yearKeywords = year.split("\\s+");
+            List<String> yearKeywordsList = Arrays.asList(yearKeywords);
+            findStudentDescriptor.setYearPredicate(new YearMatchPredicate(yearKeywordsList));
         }
 
         if (!findStudentDescriptor.isAnyPredicatePresent()) {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -62,7 +62,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(FindCommand.FIELD_NOT_GIVEN);
         }
 
-        return new FindCommand(findStudentDescriptor.getPredicates());
+        return new FindCommand(findStudentDescriptor);
     }
 
     /**
@@ -73,4 +73,21 @@ public class FindCommandParser implements Parser<FindCommand> {
         return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindCommandParser)) {
+            return false;
+        }
+
+        // state check
+        FindCommandParser e = (FindCommandParser) other;
+
+        return true;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -73,21 +73,4 @@ public class FindCommandParser implements Parser<FindCommand> {
         return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
-    @Override
-    public boolean equals(Object other) {
-        // short circuit if same object
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof FindCommandParser)) {
-            return false;
-        }
-
-        // state check
-        FindCommandParser e = (FindCommandParser) other;
-
-        return true;
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,22 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.FIND_SUPPORTED_PREFIXES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHOOL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.SchoolContainsKeywordsPredicate;
+import seedu.address.model.student.Year;
+import seedu.address.model.student.YearMatchPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +29,48 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, FIND_SUPPORTED_PREFIXES);
+
+        if (!anyPrefixesPresent(argMultimap, FIND_SUPPORTED_PREFIXES)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        FindCommand.FindStudentDescriptor findStudentDescriptor = new FindCommand.FindStudentDescriptor();
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String name = argMultimap.getValue(PREFIX_NAME).get();
+            String[] nameKeywords = name.split("\\s+");
+            List<String> nameKeywordsList = Arrays.asList(nameKeywords);
+            findStudentDescriptor.setNamePredicate(new NameContainsKeywordsPredicate(nameKeywordsList));
+        }
+        if (argMultimap.getValue(PREFIX_SCHOOL).isPresent()) {
+            String school = argMultimap.getValue(PREFIX_SCHOOL).get();
+            String[] schoolKeywords = school.split("\\s+");
+            List<String> schoolKeywordsList = Arrays.asList(schoolKeywords);
+            findStudentDescriptor.setSchoolPredicate(new SchoolContainsKeywordsPredicate(schoolKeywordsList));
+        }
+        if (argMultimap.getValue(PREFIX_YEAR).isPresent()) {
+            String year = argMultimap.getValue(PREFIX_YEAR).get();
+            Year parsedYear = ParserUtil.parseYear(year);
+            findStudentDescriptor.setYearPredicate(new YearMatchPredicate(parsedYear));
+        }
+
+        if (!findStudentDescriptor.isAnyPredicatePresent()) {
+            throw new ParseException(FindCommand.FIELD_NOT_GIVEN);
+        }
+
+        return new FindCommand(findStudentDescriptor.getPredicates());
+    }
+
+    /**
+     * Returns true if not all of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean anyPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/model/student/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/NameContainsKeywordsPredicate.java
@@ -9,7 +9,7 @@ import seedu.address.commons.util.StringUtil;
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Student> {
-    private final List<String> keywords;
+    public final List<String> keywords;
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;

--- a/src/main/java/seedu/address/model/student/SchoolContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/SchoolContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.student;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Student}'s {@code School} matches any of the keywords given.
+ */
+public class SchoolContainsKeywordsPredicate implements Predicate<Student> {
+    private final List<String> keywords;
+
+    public SchoolContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(student.getSchool().school, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SchoolContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((SchoolContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/student/SchoolContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/SchoolContainsKeywordsPredicate.java
@@ -17,8 +17,12 @@ public class SchoolContainsKeywordsPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
+        if (this.keywords.size() < 1) {
+            return false;
+        }
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(student.getSchool().school, keyword));
+                .map(String::toLowerCase)
+                .allMatch(keyword -> StringUtil.containsIgnoreCase(student.getSchool().school, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/SchoolContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/SchoolContainsKeywordsPredicate.java
@@ -9,7 +9,7 @@ import seedu.address.commons.util.StringUtil;
  * Tests that a {@code Student}'s {@code School} matches any of the keywords given.
  */
 public class SchoolContainsKeywordsPredicate implements Predicate<Student> {
-    private final List<String> keywords;
+    public final List<String> keywords;
 
     public SchoolContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;

--- a/src/main/java/seedu/address/model/student/YearMatchPredicate.java
+++ b/src/main/java/seedu/address/model/student/YearMatchPredicate.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 
+
 /**
  * Tests that a {@code Student}'s {@code Year} matches the given year.
  */
@@ -20,8 +21,12 @@ public class YearMatchPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
+        if (this.keywords.size() < 1) {
+            return false;
+        }
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(student.getYear().year, keyword));
+                .map(String::toLowerCase)
+                .allMatch(keyword -> StringUtil.containsIgnoreCase(student.getYear().year, keyword));
     }
 
     @Override
@@ -30,6 +35,5 @@ public class YearMatchPredicate implements Predicate<Student> {
                 || (other instanceof YearMatchPredicate // instanceof handles nulls
                 && this.keywords.equals(((YearMatchPredicate) other).keywords)); // state check
     }
-
 
 }

--- a/src/main/java/seedu/address/model/student/YearMatchPredicate.java
+++ b/src/main/java/seedu/address/model/student/YearMatchPredicate.java
@@ -1,6 +1,9 @@
 package seedu.address.model.student;
 
+import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Student}'s {@code Year} matches the given year.
@@ -8,23 +11,24 @@ import java.util.function.Predicate;
 public class YearMatchPredicate implements Predicate<Student> {
 
     // Attributes
-    public final Year year;
+    public final List<String> keywords;
 
     // Constructor
-    public YearMatchPredicate(Year year) {
-        this.year = year;
+    public YearMatchPredicate(List<String> keywords) {
+        this.keywords = keywords;
     }
 
     @Override
     public boolean test(Student student) {
-        return this.year.equals(student.getYear());
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(student.getYear().year, keyword));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof YearMatchPredicate // instanceof handles nulls
-                && this.year.equals(((YearMatchPredicate) other).year)); // state check
+                && this.keywords.equals(((YearMatchPredicate) other).keywords)); // state check
     }
 
 

--- a/src/main/java/seedu/address/model/student/YearMatchPredicate.java
+++ b/src/main/java/seedu/address/model/student/YearMatchPredicate.java
@@ -8,7 +8,7 @@ import java.util.function.Predicate;
 public class YearMatchPredicate implements Predicate<Student> {
 
     // Attributes
-    private final Year year;
+    public final Year year;
 
     // Constructor
     public YearMatchPredicate(Year year) {

--- a/src/main/java/seedu/address/model/student/YearMatchPredicate.java
+++ b/src/main/java/seedu/address/model/student/YearMatchPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.student;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Student}'s {@code Year} matches the given year.
+ */
+public class YearMatchPredicate implements Predicate<Student> {
+
+    // Attributes
+    private final Year year;
+
+    // Constructor
+    public YearMatchPredicate(Year year) {
+        this.year = year;
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return this.year.equals(student.getYear());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof YearMatchPredicate // instanceof handles nulls
+                && this.year.equals(((YearMatchPredicate) other).year)); // state check
+    }
+
+
+}

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -123,6 +123,54 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
     }
 
+    /*
+     * Valid equivalence partitions for word:
+     *   - any word
+     *   - word containing symbols/numbers
+     *   - word with leading/trailing spaces
+     *
+     * Valid equivalence partitions for sentence:
+     *   - empty string
+     *   - one word
+     *   - multiple words
+     *   - sentence with extra spaces
+     *
+     * Possible scenarios returning true:
+     *   - matches first word in sentence
+     *   - last word in sentence
+     *   - middle word in sentence
+     *   - matches multiple words
+     *   - query word matches part of a sentence word
+
+     *
+     * Possible scenarios returning false:
+     *   - sentence word matches part of the query word
+     *
+     * The test method below tries to verify all above with a reasonably low number of test cases.
+     */
+
+    @Test
+    public void containsIgnoreCase_validInputs_correctResult() {
+
+        // Empty sentence
+        assertFalse(StringUtil.containsIgnoreCase("", "abc")); // Boundary case
+        assertFalse(StringUtil.containsIgnoreCase("    ", "123"));
+
+        // Matches a partial word
+        assertTrue(StringUtil.containsIgnoreCase("aaa bbb ccc", "bb")); // sentence contains word
+        assertFalse(StringUtil.containsIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
+
+        // Matches word in the sentence, different upper/lower case letters
+        assertTrue(StringUtil.containsIgnoreCase("aaa bBb ccc", "Bbb")); // First word (boundary case)
+        assertTrue(StringUtil.containsIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
+        assertTrue(StringUtil.containsIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
+        assertTrue(StringUtil.containsIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
+        assertTrue(StringUtil.containsIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
+
+        // Matches multiple words in sentence
+        assertTrue(StringUtil.containsIgnoreCase("AAA bBb ccc  bbb", "bbB"));
+    }
+
     //---------------- Tests for getDetails --------------------------------------
 
     /*

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -96,7 +96,7 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Kurz Elle Kunz");
         SchoolContainsKeywordsPredicate schoolPredicate = prepareSchoolPredicate("Girls School");
-        YearMatchPredicate yearMatchPredicate = prepareYearPredicate("year 2");
+        YearMatchPredicate yearMatchPredicate = prepareYearPredicate("2");
         List<Predicate<Student>> predicates = Arrays.asList(namePredicate,
                 schoolPredicate, yearMatchPredicate);
         Predicate<Student> consolidatedPredicates = consolidatePredicates(predicates);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -17,7 +17,6 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -127,7 +126,7 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code YearMatchPredicate}.
      */
     private YearMatchPredicate prepareYearPredicate(String userInput) throws ParseException {
-        return new YearMatchPredicate(ParserUtil.parseYear(userInput));
+        return new YearMatchPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -93,7 +93,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multiplePredicates_multipleStudentsFound() {
+    public void execute_multiplePredicates_oneStudentsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Kurz Elle Kunz");
         SchoolContainsKeywordsPredicate schoolPredicate = prepareSchoolPredicate("Girls School");

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalStudents.ELLE;
 import static seedu.address.testutil.TypicalStudents.FIONA;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -92,20 +93,41 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multiplePredicates_multiplePersonsFound() {
+    public void execute_multiplePredicates_multipleStudentsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Kurz Elle Kunz");
         SchoolContainsKeywordsPredicate schoolPredicate = prepareSchoolPredicate("Girls School");
-        List<Predicate<Student>> predicates = Arrays.asList(namePredicate, schoolPredicate);
+        YearMatchPredicate yearMatchPredicate = prepareYearPredicate("year 2");
+        List<Predicate<Student>> predicates = Arrays.asList(namePredicate, schoolPredicate, yearMatchPredicate);
         Predicate<Student> consolidatedPredicates = consolidatePredicates(predicates);
         expectedModel.updateFilteredPersonList(consolidatedPredicates);
 
         FindCommand.FindStudentDescriptor descriptor = new FindStudentDescriptorBuilder()
-                .withNamePredicate(namePredicate).withSchoolPredicate(schoolPredicate).build();
+                .withNamePredicate(namePredicate).withSchoolPredicate(schoolPredicate)
+                .withYearPredicate(yearMatchPredicate).build();
         FindCommand command = new FindCommand(descriptor);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multiplePredicates_noStudentFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Kurz Elle Kunz");
+        SchoolContainsKeywordsPredicate schoolPredicate = prepareSchoolPredicate("Girls School");
+        YearMatchPredicate yearMatchPredicate = prepareYearPredicate("sec 3");
+        List<Predicate<Student>> predicates = Arrays.asList(namePredicate, schoolPredicate, yearMatchPredicate);
+        Predicate<Student> consolidatedPredicates = consolidatePredicates(predicates);
+        expectedModel.updateFilteredPersonList(consolidatedPredicates);
+
+        FindCommand.FindStudentDescriptor descriptor = new FindStudentDescriptorBuilder()
+                .withNamePredicate(namePredicate).withSchoolPredicate(schoolPredicate)
+                .withYearPredicate(yearMatchPredicate).build();
+        FindCommand command = new FindCommand(descriptor);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(new ArrayList<>(), model.getFilteredPersonList());
     }
 
     /**
@@ -125,7 +147,7 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code YearMatchPredicate}.
      */
-    private YearMatchPredicate prepareYearPredicate(String userInput) throws ParseException {
+    private YearMatchPredicate prepareYearPredicate(String userInput) {
         return new YearMatchPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,7 +18,6 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -98,7 +97,8 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Kurz Elle Kunz");
         SchoolContainsKeywordsPredicate schoolPredicate = prepareSchoolPredicate("Girls School");
         YearMatchPredicate yearMatchPredicate = prepareYearPredicate("year 2");
-        List<Predicate<Student>> predicates = Arrays.asList(namePredicate, schoolPredicate, yearMatchPredicate);
+        List<Predicate<Student>> predicates = Arrays.asList(namePredicate,
+                schoolPredicate, yearMatchPredicate);
         Predicate<Student> consolidatedPredicates = consolidatePredicates(predicates);
         expectedModel.updateFilteredPersonList(consolidatedPredicates);
 
@@ -117,7 +117,8 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Kurz Elle Kunz");
         SchoolContainsKeywordsPredicate schoolPredicate = prepareSchoolPredicate("Girls School");
         YearMatchPredicate yearMatchPredicate = prepareYearPredicate("sec 3");
-        List<Predicate<Student>> predicates = Arrays.asList(namePredicate, schoolPredicate, yearMatchPredicate);
+        List<Predicate<Student>> predicates = Arrays.asList(namePredicate,
+                schoolPredicate, yearMatchPredicate);
         Predicate<Student> consolidatedPredicates = consolidatePredicates(predicates);
         expectedModel.updateFilteredPersonList(consolidatedPredicates);
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -12,13 +12,20 @@ import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.SchoolContainsKeywordsPredicate;
+import seedu.address.model.student.Student;
+import seedu.address.model.student.YearMatchPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -34,14 +41,17 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        List<Predicate<Student>> firstGroupOfPredicates = Collections.singletonList(firstPredicate);
+        List<Predicate<Student>> secondGroupOfPredicates = Collections.singletonList(secondPredicate);
+
+        FindCommand findFirstCommand = new FindCommand(firstGroupOfPredicates);
+        FindCommand findSecondCommand = new FindCommand(secondGroupOfPredicates);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstGroupOfPredicates);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -57,8 +67,9 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
+        List<Predicate<Student>> groupOfPredicates = Collections.singletonList(predicate);
+        FindCommand command = new FindCommand(groupOfPredicates);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
@@ -67,8 +78,9 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
+        List<Predicate<Student>> groupOfPredicates = Collections.singletonList(predicate);
+        FindCommand command = new FindCommand(groupOfPredicates);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
@@ -77,7 +89,21 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code SchoolContainsKeywordsPredicate}.
+     */
+    private SchoolContainsKeywordsPredicate prepareSchoolPredicate(String userInput) {
+        return new SchoolContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code YearMatchPredicate}.
+     */
+    private YearMatchPredicate prepareYearPredicate(String userInput) throws ParseException {
+        return new YearMatchPredicate(ParserUtil.parseYear(userInput));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -5,13 +5,13 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.SchoolContainsKeywordsPredicate;
-import seedu.address.model.student.Year;
 import seedu.address.model.student.YearMatchPredicate;
 import seedu.address.testutil.FindStudentDescriptorBuilder;
 
@@ -45,7 +45,7 @@ public class FindCommandParserTest {
         NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         SchoolContainsKeywordsPredicate schoolPredicate =
                 new SchoolContainsKeywordsPredicate(Arrays.asList("Changi", "Sec"));
-        YearMatchPredicate yearPredicate = new YearMatchPredicate(new Year("3"));
+        YearMatchPredicate yearPredicate = new YearMatchPredicate(Collections.singletonList("3"));
 
         FindCommand.FindStudentDescriptor descriptor = new FindStudentDescriptorBuilder()
                 .withNamePredicate(namePredicate)

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -5,11 +5,19 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.SchoolContainsKeywordsPredicate;
+import seedu.address.model.student.Student;
+import seedu.address.model.student.Year;
+import seedu.address.model.student.YearMatchPredicate;
 
 public class FindCommandParserTest {
 
@@ -22,13 +30,31 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
+
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        FindCommand expectedFindCommand = new FindCommand(Collections.singletonList(predicate));
+        assertParseSuccess(parser, " n/Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " n/ \n Alice \n \t Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validArgsCompoundPredicates_returnsFindCommand() {
+
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        SchoolContainsKeywordsPredicate schoolPredicate =
+                new SchoolContainsKeywordsPredicate(Arrays.asList("Changi", "Sec"));
+        YearMatchPredicate yearPredicate = new YearMatchPredicate(new Year("3"));
+        List<Predicate<Student>> predicates = Arrays.asList(namePredicate, schoolPredicate, yearPredicate);
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand = new FindCommand(predicates);
+        assertParseSuccess(parser, " n/Alice Bob s/Changi Sec y/3", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser,
+                " n/ \n Alice \n \t Bob  \n s/Changi\t Sec\t \t y/3", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -12,7 +12,6 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.SchoolContainsKeywordsPredicate;
 import seedu.address.model.student.Student;

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -5,18 +5,15 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.SchoolContainsKeywordsPredicate;
-import seedu.address.model.student.Student;
 import seedu.address.model.student.Year;
 import seedu.address.model.student.YearMatchPredicate;
+import seedu.address.testutil.FindStudentDescriptorBuilder;
 
 public class FindCommandParserTest {
 
@@ -31,8 +28,11 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
 
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        FindCommand.FindStudentDescriptor descriptor =
+                new FindStudentDescriptorBuilder().withNamePredicate(predicate).build();
+
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand = new FindCommand(Collections.singletonList(predicate));
+        FindCommand expectedFindCommand = new FindCommand(descriptor);
         assertParseSuccess(parser, " n/Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
@@ -46,9 +46,15 @@ public class FindCommandParserTest {
         SchoolContainsKeywordsPredicate schoolPredicate =
                 new SchoolContainsKeywordsPredicate(Arrays.asList("Changi", "Sec"));
         YearMatchPredicate yearPredicate = new YearMatchPredicate(new Year("3"));
-        List<Predicate<Student>> predicates = Arrays.asList(namePredicate, schoolPredicate, yearPredicate);
+
+        FindCommand.FindStudentDescriptor descriptor = new FindStudentDescriptorBuilder()
+                .withNamePredicate(namePredicate)
+                .withSchoolPredicate(schoolPredicate)
+                .withYearPredicate(yearPredicate)
+                .build();
+
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand = new FindCommand(predicates);
+        FindCommand expectedFindCommand = new FindCommand(descriptor);
         assertParseSuccess(parser, " n/Alice Bob s/Changi Sec y/3", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/address/logic/parser/ReeveParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ReeveParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,9 +71,10 @@ public class ReeveParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords);
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(Collections.singletonList(predicate)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ReeveParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ReeveParserTest.java
@@ -8,9 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +24,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.Student;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
+import seedu.address.testutil.FindStudentDescriptorBuilder;
 import seedu.address.testutil.StudentBuilder;
 import seedu.address.testutil.StudentUtil;
 
@@ -71,10 +70,12 @@ public class ReeveParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords);
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(keywords);
+        FindCommand.FindStudentDescriptor descriptor = new FindStudentDescriptorBuilder()
+                .withNamePredicate(namePredicate).build();
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(Collections.singletonList(predicate)), command);
+                FindCommand.COMMAND_WORD + " " + StudentUtil.getFindStudentDescriptorDetails(descriptor));
+        assertEquals(new FindCommand(descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/NameContainsKeywordsPredicateTest.java
@@ -64,12 +64,16 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new StudentBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Carol"));
         assertFalse(predicate.test(new StudentBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
         assertFalse(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
                 .build()));
+
+        // User guide test cases
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alex", "david"));
+        assertFalse(predicate.test(new StudentBuilder().withName("Alexis davinder").build()));
     }
 }

--- a/src/test/java/seedu/address/model/student/SchoolContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/SchoolContainsKeywordsPredicateTest.java
@@ -42,33 +42,29 @@ public class SchoolContainsKeywordsPredicateTest {
     }
 
     @Test
-    public void test_nameContainsKeywords_returnsTrue() {
-        // One keyword
+    public void test_schoolContainsAllKeywords_returnsTrue() {
+        // One keyword different case
         SchoolContainsKeywordsPredicate predicate =
                 new SchoolContainsKeywordsPredicate(Collections.singletonList("Changi"));
         assertTrue(predicate.test(new StudentBuilder().withSchool("changi").build()));
 
-        // Multiple keywords
+        // Multiple keywords same case
         predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("Kent", "Ridge"));
         assertTrue(predicate.test(new StudentBuilder().withSchool("Kent Ridge").build()));
-
-        // Only one matching keyword
-        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("Kent", "Ridge"));
-        assertTrue(predicate.test(new StudentBuilder().withSchool("Kent Vale").build()));
 
         // Mixed-case keywords
         predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("KeNt", "RiDGE"));
         assertTrue(predicate.test(new StudentBuilder().withSchool("kent ridge").build()));
 
         // User guide test cases
-        predicate = new SchoolContainsKeywordsPredicate(Collections.singletonList("yishun"));
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("yishun", "sec"));
         assertTrue(predicate.test(new StudentBuilder().withSchool("Yishun Secondary School").build()));
         assertTrue(predicate.test(new StudentBuilder().withSchool("Yishun Town Secondary School").build()));
 
     }
 
     @Test
-    public void test_nameDoesNotContainKeywords_returnsFalse() {
+    public void test_schoolDoesNotContainAllKeywords_returnsFalse() {
         // Zero keywords
         SchoolContainsKeywordsPredicate predicate = new SchoolContainsKeywordsPredicate(Collections.emptyList());
         assertFalse(predicate.test(new StudentBuilder().withSchool("Changi").build()));
@@ -77,9 +73,18 @@ public class SchoolContainsKeywordsPredicateTest {
         predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("Science"));
         assertFalse(predicate.test(new StudentBuilder().withSchool("School of Computing").build()));
 
+        // One keyword matching one not matching
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("Kent", "Ridge"));
+        assertFalse(predicate.test(new StudentBuilder().withSchool("Kent Vale").build()));
+
         // Keywords match phone, email and address, but does not match school
         predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
         assertFalse(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
                 .build()));
+
+        // User guide test cases
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("yishun", "secondary"));
+        assertFalse(predicate.test(new StudentBuilder().withSchool("Yishun sec").build()));
+
     }
 }

--- a/src/test/java/seedu/address/model/student/SchoolContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/SchoolContainsKeywordsPredicateTest.java
@@ -1,0 +1,85 @@
+package seedu.address.model.student;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.StudentBuilder;
+
+public class SchoolContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Changi");
+        List<String> secondPredicateKeywordList = Arrays.asList("Kent", "Ridge");
+
+        SchoolContainsKeywordsPredicate firstPredicate =
+                new SchoolContainsKeywordsPredicate(firstPredicateKeywordList);
+        SchoolContainsKeywordsPredicate secondPredicate =
+                new SchoolContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        SchoolContainsKeywordsPredicate firstPredicateCopy =
+                new SchoolContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        SchoolContainsKeywordsPredicate predicate =
+                new SchoolContainsKeywordsPredicate(Collections.singletonList("Changi"));
+        assertTrue(predicate.test(new StudentBuilder().withSchool("changi").build()));
+
+        // Multiple keywords
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("Kent", "Ridge"));
+        assertTrue(predicate.test(new StudentBuilder().withSchool("Kent Ridge").build()));
+
+        // Only one matching keyword
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("Kent", "Ridge"));
+        assertTrue(predicate.test(new StudentBuilder().withSchool("Kent Vale").build()));
+
+        // Mixed-case keywords
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("KeNt", "RiDGE"));
+        assertTrue(predicate.test(new StudentBuilder().withSchool("kent ridge").build()));
+
+        // User guide test cases
+        predicate = new SchoolContainsKeywordsPredicate(Collections.singletonList("yishun"));
+        assertTrue(predicate.test(new StudentBuilder().withSchool("Yishun Secondary School").build()));
+        assertTrue(predicate.test(new StudentBuilder().withSchool("Yishun Town Secondary School").build()));
+
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        SchoolContainsKeywordsPredicate predicate = new SchoolContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new StudentBuilder().withSchool("Changi").build()));
+
+        // Non-matching keyword
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("Science"));
+        assertFalse(predicate.test(new StudentBuilder().withSchool("School of Computing").build()));
+
+        // Keywords match phone, email and address, but does not match school
+        predicate = new SchoolContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new StudentBuilder().withName("Alice").withPhone("12345")
+                .build()));
+    }
+}

--- a/src/test/java/seedu/address/model/student/YearMatchPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/YearMatchPredicateTest.java
@@ -5,22 +5,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.StudentBuilder;
 
 public class YearMatchPredicateTest {
 
-    private Year yearOne = new Year("1");
-    private Year yearTwo = new Year("2");
+    private YearMatchPredicate yearMatchPredicateOne = new YearMatchPredicate(Collections.singletonList("1"));
+    private YearMatchPredicate yearMatchPredicateTwo = new YearMatchPredicate(Collections.singletonList("2"));
 
-    private YearMatchPredicate yearMatchPredicateOne = new YearMatchPredicate(yearOne);
-    private YearMatchPredicate yearMatchPredicateTwo = new YearMatchPredicate(yearTwo);
-
-    private YearMatchPredicate yearMatchPredicateOneDuplicate = new YearMatchPredicate(yearOne);
+    private YearMatchPredicate yearMatchPredicateOneDuplicate =
+            new YearMatchPredicate(Collections.singletonList("1"));
 
     private Student yearOneStudent = new StudentBuilder().withName("Alice").withSchool("Changi Junior College")
-            .withYear("1").build();
+            .withYear("sec 1").build();
     private Student yearTwoStudent = new StudentBuilder().withName("Pikachu").withSchool("Trainers School")
             .withYear("2").build();
 
@@ -31,7 +31,7 @@ public class YearMatchPredicateTest {
         assertEquals(yearMatchPredicateOne, yearMatchPredicateOne);
 
         // different type -> return false
-        assertNotEquals(yearOne, yearMatchPredicateOne);
+        assertNotEquals("1", yearMatchPredicateOne);
 
         // null -> returns false
         assertNotEquals(yearMatchPredicateOne, null);

--- a/src/test/java/seedu/address/model/student/YearMatchPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/YearMatchPredicateTest.java
@@ -1,0 +1,56 @@
+package seedu.address.model.student;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.StudentBuilder;
+
+public class YearMatchPredicateTest {
+
+    private Year yearOne = new Year("1");
+    private Year yearTwo = new Year("2");
+
+    private YearMatchPredicate yearMatchPredicateOne = new YearMatchPredicate(yearOne);
+    private YearMatchPredicate yearMatchPredicateTwo = new YearMatchPredicate(yearTwo);
+
+    private YearMatchPredicate yearMatchPredicateOneDuplicate = new YearMatchPredicate(yearOne);
+
+    private Student yearOneStudent = new StudentBuilder().withName("Alice").withSchool("Changi Junior College")
+            .withYear("1").build();
+    private Student yearTwoStudent = new StudentBuilder().withName("Pikachu").withSchool("Trainers School")
+            .withYear("2").build();
+
+    @Test
+    public void equals() {
+
+        // same object -> returns true
+        assertEquals(yearMatchPredicateOne, yearMatchPredicateOne);
+
+        // different type -> return false
+        assertNotEquals(yearOne, yearMatchPredicateOne);
+
+        // null -> returns false
+        assertNotEquals(yearMatchPredicateOne, null);
+
+        // same year -> returns true
+        assertTrue(yearMatchPredicateOne.equals(yearMatchPredicateOneDuplicate));
+
+        // different year -> returns false
+        assertFalse(yearMatchPredicateOne.equals(yearMatchPredicateTwo));
+
+    }
+
+    @Test
+    public void test_matchingYear_returnsTrue() {
+        assertTrue(yearMatchPredicateOne.test(yearOneStudent));
+    }
+
+    @Test
+    public void test_notMatchingYear_returnsFalse() {
+        assertFalse(yearMatchPredicateOne.test(yearTwoStudent));
+    }
+}

--- a/src/test/java/seedu/address/model/student/YearMatchPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/YearMatchPredicateTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -13,14 +14,14 @@ import seedu.address.testutil.StudentBuilder;
 
 public class YearMatchPredicateTest {
 
-    private YearMatchPredicate yearMatchPredicateOne = new YearMatchPredicate(Collections.singletonList("1"));
+    private YearMatchPredicate yearMatchPredicateOne = new YearMatchPredicate(Arrays.asList("sec", "1"));
     private YearMatchPredicate yearMatchPredicateTwo = new YearMatchPredicate(Collections.singletonList("2"));
 
     private YearMatchPredicate yearMatchPredicateOneDuplicate =
-            new YearMatchPredicate(Collections.singletonList("1"));
+            new YearMatchPredicate(Arrays.asList("sec", "1"));
 
     private Student yearOneStudent = new StudentBuilder().withName("Alice").withSchool("Changi Junior College")
-            .withYear("sec 1").build();
+            .withYear("secondary 1").build();
     private Student yearTwoStudent = new StudentBuilder().withName("Pikachu").withSchool("Trainers School")
             .withYear("2").build();
 
@@ -47,10 +48,20 @@ public class YearMatchPredicateTest {
     @Test
     public void test_matchingYear_returnsTrue() {
         assertTrue(yearMatchPredicateOne.test(yearOneStudent));
+
+        // User guide test cases
+        YearMatchPredicate predicate = new YearMatchPredicate(Arrays.asList("sec", "3"));
+        assertTrue(predicate.test(new StudentBuilder().withYear("sec 3").build()));
+        assertTrue(predicate.test(new StudentBuilder().withYear("Secondary 3").build()));
+
     }
 
     @Test
     public void test_notMatchingYear_returnsFalse() {
         assertFalse(yearMatchPredicateOne.test(yearTwoStudent));
+
+        // User guide test cases
+        YearMatchPredicate predicate = new YearMatchPredicate(Arrays.asList("sec", "3"));
+        assertFalse(predicate.test(new StudentBuilder().withYear("sec 4").build()));
     }
 }

--- a/src/test/java/seedu/address/testutil/FindStudentDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/FindStudentDescriptorBuilder.java
@@ -1,0 +1,51 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.FindCommand.FindStudentDescriptor;
+import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.SchoolContainsKeywordsPredicate;
+import seedu.address.model.student.YearMatchPredicate;
+
+
+/**
+ * A utility class to help with building FindStudentDescriptor objects.
+ */
+public class FindStudentDescriptorBuilder {
+
+    private FindStudentDescriptor descriptor;
+
+    public FindStudentDescriptorBuilder() {
+        descriptor = new FindStudentDescriptor();
+    }
+
+    public FindStudentDescriptorBuilder(FindStudentDescriptor descriptor) {
+        this.descriptor = new FindStudentDescriptor(descriptor);
+    }
+
+    /**
+     * Sets the {@code namePredicate} of the {@code FindStudentDescriptor} that we are building.
+     */
+    public FindStudentDescriptorBuilder withNamePredicate(NameContainsKeywordsPredicate namePredicate) {
+        descriptor.setNamePredicate(namePredicate);
+        return this;
+    }
+
+    /**
+     * Sets the {@code schoolPredicate} of the {@code FindStudentDescriptor} that we are building.
+     */
+    public FindStudentDescriptorBuilder withSchoolPredicate(SchoolContainsKeywordsPredicate schoolPredicate) {
+        descriptor.setSchoolPredicate(schoolPredicate);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Year} of the {@code FindStudentDescriptor} that we are building.
+     */
+    public FindStudentDescriptorBuilder withYearPredicate(YearMatchPredicate yearPredicate) {
+        descriptor.setYearPredicate(yearPredicate);
+        return this;
+    }
+
+    public FindStudentDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/StudentUtil.java
+++ b/src/test/java/seedu/address/testutil/StudentUtil.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.student.Student;
 
 /**
@@ -43,6 +44,27 @@ public class StudentUtil {
         descriptor.getSchool().ifPresent(school -> sb.append(PREFIX_SCHOOL).append(school.school).append(" "));
         descriptor.getYear().ifPresent(year -> sb.append(PREFIX_YEAR).append(year.year).append(" "));
 
+        return sb.toString();
+    }
+
+    /**
+     * Returns the part of command string for the given {@code FindStudentDescriptor}'s details.
+     */
+    public static String getFindStudentDescriptorDetails(FindCommand.FindStudentDescriptor descriptor) {
+        StringBuilder sb = new StringBuilder();
+        descriptor.getNamePredicate().ifPresent(predicate -> {
+            String stringName = predicate.keywords.stream() // Convert the keywords list in predicate into a string
+                    .reduce("", (x, y) -> x + " " + y);
+            sb.append(PREFIX_NAME).append(stringName).append(" ");
+        });
+        descriptor.getSchoolPredicate().ifPresent(predicate -> {
+            String stringSchool = predicate.keywords.stream() // Convert the keywords list in predicate into a string
+                    .reduce("", (x, y) -> x + " " + y);
+            sb.append(PREFIX_SCHOOL).append(stringSchool).append(" ");
+        });
+        descriptor.getYearPredicate().ifPresent(year -> sb.append(PREFIX_YEAR).append(year.year).append(" "));
+
+        System.out.println(sb.toString());
         return sb.toString();
     }
 }

--- a/src/test/java/seedu/address/testutil/StudentUtil.java
+++ b/src/test/java/seedu/address/testutil/StudentUtil.java
@@ -62,7 +62,11 @@ public class StudentUtil {
                     .reduce("", (x, y) -> x + " " + y);
             sb.append(PREFIX_SCHOOL).append(stringSchool).append(" ");
         });
-        descriptor.getYearPredicate().ifPresent(year -> sb.append(PREFIX_YEAR).append(year.year).append(" "));
+        descriptor.getYearPredicate().ifPresent(predicate -> {
+            String stringYear = predicate.keywords.stream() // Convert the keywords list in predicate into a string
+                    .reduce("", (x, y) -> x + " " + y);
+            sb.append(PREFIX_YEAR).append(stringYear).append(" ");
+        });
 
         System.out.println(sb.toString());
         return sb.toString();

--- a/src/test/java/seedu/address/testutil/StudentUtil.java
+++ b/src/test/java/seedu/address/testutil/StudentUtil.java
@@ -68,7 +68,6 @@ public class StudentUtil {
             sb.append(PREFIX_YEAR).append(stringYear).append(" ");
         });
 
-        System.out.println(sb.toString());
         return sb.toString();
     }
 }


### PR DESCRIPTION
Modifies find command to support searching by name, school and year. Need to specify at least one but can specify more than one filter criteria.

Closes #11 
Closes #12 
Closes #13 


Things added
- Individual Predicates
- `FindStudentDescriptor`: consisting of `NamePredicate`, `SchoolPredicate` and `YearPredicate` 
- Updated `FindCommand` to require the use of `FindStudentDescriptor` instead of just the name predicate
- `StringUtil::containsIgnoreCase` method to check for whether sentence contains word but ignoring case: implementation is similar to `containsWordIgnoreCase` but has an additional check now to return false if sentence given is empty as the final step uses `contains` instead of `equalsIgnoreCase` which is more relaxed

Updated
- Prefixes supported by find command
- Descriptions of usage
- User guide description of behaviour

Behaviour
- NamePredicate (type `NameContainsKeywordsPredicate`): checks whether (`List<String>`) argument provided has at least one word in the student's name
- SchoolPredicate (type `SchoolContainsKeywordsPredicate`): checks whether all words in (`List<String>` keywords) argument are contained in part of the school.
    Additional details
    - Checks whether keywords in predicate has at least one word otherwise returns false when testing (currently to match test case behaviour for name predicate but can be changed).
- YearPredicate (type `YearMatchPredicatePredicate`): checks whether all words in (`List<String>` keywords) argument are contained in part of the year.
    Additional details
    - Checks whether keywords in predicate has at least one word otherwise returns false when testing (currently to match test case behaviour for name predicate but can be changed).


