### PR TITLE
Improve String representation of student

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -44,7 +44,7 @@ public class AddCommand extends Command {
             + PREFIX_PAYMENT + "24/09/2020 "
             + PREFIX_DETAILS + "Additional details here ";
 
-    public static final String MESSAGE_SUCCESS = "New student added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New student added:\n%1$s";
     public static final String MESSAGE_DUPLICATE_STUDENT = "This student already exists in Reeve";
 
     private final Student toAdd;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -55,7 +55,7 @@ public class EditCommand extends Command {
             + PREFIX_VENUE + "Anderson Junior College"
             + PREFIX_TIME + "2 1300-1400";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Student: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Student:\n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This student already exists in Reeve.";
 

--- a/src/main/java/seedu/address/model/student/School.java
+++ b/src/main/java/seedu/address/model/student/School.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class School {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "School names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "School name can take any values, and should not be blank";
 
     /*
      * School names must have at least 1 alphabet with spaces in between allowed.
      * First character cannot be empty string if not empty string becomes valid school.
      */
-    public static final String VALIDATION_REGEX = "^[A-Za-z][A-Za-z ]*$";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String school;
 

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import seedu.address.model.student.admin.AdditionalDetail;
 import seedu.address.model.student.admin.Admin;
@@ -116,16 +117,24 @@ public class Student {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(getName())
-                .append(" Phone: ")
+        builder.append("Name: ")
+                .append(getName())
+                .append("\nPhone: ")
                 .append(getPhone())
-                .append(" School: ")
+                .append("\nSchool: ")
                 .append(getSchool())
-                .append(" Year: ")
+                .append("\nYear: ")
                 .append(getYear())
-                .append(getAdmin())
-                .append(" Questions: ");
-        questions.forEach(builder::append);
+                .append(getAdmin());
+
+        if (!questions.isEmpty()) {
+            builder.append("\nQuestions:\n");
+            String questionList = questions.stream()
+                    .map(Question::toString)
+                    .collect(Collectors.joining("\n"));
+            builder.append(questionList);
+        }
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/student/admin/Admin.java
+++ b/src/main/java/seedu/address/model/student/admin/Admin.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Represents all administrative details of a Student in Reeve.
@@ -90,16 +91,22 @@ public class Admin {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(" Class Venue: ")
+        builder.append("\nClass Venue: ")
                 .append(classVenue)
-                .append(" Lesson Times: ")
+                .append("\nLesson Times: ")
                 .append(classTime)
-                .append(" Fee: ")
+                .append("\nFee: ")
                 .append(fee)
-                .append(" Last Paid: ")
-                .append(paymentDate)
-                .append(" Details: ");
-        details.forEach(builder::append);
+                .append("\nLast Paid: ")
+                .append(paymentDate);
+
+        if (!details.isEmpty()) {
+            builder.append("\nDetails:\n");
+            String detailList = details.stream()
+                    .map(AdditionalDetail::toString)
+                    .collect(Collectors.joining("\n"));
+            builder.append(detailList);
+        }
         return builder.toString();
     }
 }

--- a/src/main/java/seedu/address/model/student/admin/Admin.java
+++ b/src/main/java/seedu/address/model/student/admin/Admin.java
@@ -103,7 +103,7 @@ public class Admin {
         if (!details.isEmpty()) {
             builder.append("\nDetails:\n");
             String detailList = details.stream()
-                    .map(AdditionalDetail::toString)
+                    .map(detail -> String.format("- %s", detail))
                     .collect(Collectors.joining("\n"));
             builder.append(detailList);
         }

--- a/src/main/java/seedu/address/model/student/admin/ClassTime.java
+++ b/src/main/java/seedu/address/model/student/admin/ClassTime.java
@@ -105,7 +105,7 @@ public class ClassTime implements Comparable<ClassTime> {
     @Override
     public String toString() {
         String dayDisplayName = dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH);
-        return String.format("Day of week: %s, Start time: %s, End Time: %s",
+        return String.format("%1$s (%2$s - %3$s)",
                 dayDisplayName,
                 this.startTime.format(OUTPUT),
                 this.endTime.format(OUTPUT));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.parser.ParserUtil.parseSchool;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -28,7 +27,7 @@ import seedu.address.model.student.admin.PaymentDate;
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
-    private static final String INVALID_SCHOOL = "Method!st Girls School";
+    private static final String INVALID_SCHOOL = " ";
     private static final String INVALID_YEAR = "$4";
     private static final String INVALID_CLASS_VENUE = " ";
     private static final String INVALID_CLASS_TIME = "8 1240-2400";
@@ -127,9 +126,6 @@ public class ParserUtilTest {
     @Test
     public void parseSchool_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseSchool(INVALID_SCHOOL));
-
-        String invalidSchool = "Method!st Girls School";
-        assertThrows(ParseException.class, () -> parseSchool(invalidSchool));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/SchoolTest.java
+++ b/src/test/java/seedu/address/model/student/SchoolTest.java
@@ -27,8 +27,6 @@ public class SchoolTest {
         // invalid school names
         assertFalse(School.isValidSchool("")); // empty string
         assertFalse(School.isValidSchool(" ")); // spaces only
-        assertFalse(School.isValidSchool("123")); // numeric
-        assertFalse(School.isValidSchool("!@#$,./")); // characters
 
         // valid school name
         assertTrue(School.isValidSchool("a")); //1 small letter

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -19,7 +19,7 @@ import seedu.address.model.student.Year;
 public class JsonAdaptedStudentTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
-    private static final String INVALID_SCHOOL = "Ros#th Primary";
+    private static final String INVALID_SCHOOL = " ";
     private static final String INVALID_YEAR = "F!ck!";
 
     private static final String VALID_NAME = BOB.getName().toString();


### PR DESCRIPTION
* Student/Admin `toString()` methods now separate fields by a newline character
* Questions and details are only visible in Student/Admin `toString()` if they are not empty
* `AddCommand` and `EditCommand` command message also tweaked (with an additional newline)
* ClassTime now shows `[day of week] (start_time - end_time)`
* School name constraints relaxed since schools can have "-" and "'s" in their names too whoops
[Preferably merged with #111]

![image](https://user-images.githubusercontent.com/52755148/97017061-11966c00-1580-11eb-872f-a8110fd9bfd6.png)
![image](https://user-images.githubusercontent.com/52755148/97017102-1ce99780-1580-11eb-9f46-5715fd5c7783.png)
![image](https://user-images.githubusercontent.com/52755148/97017301-528e8080-1580-11eb-95fb-4c7fc29326c9.png)
![image](https://user-images.githubusercontent.com/52755148/97017392-6cc85e80-1580-11eb-9a13-93f44650681a.png)
