### PR TITLE
Improve date validation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -264,7 +264,7 @@ Examples:
 
 You can find all students whose date of last payment is more than a month ago.
 
-Format: `overdue unpaid`
+Format: `overdue`
 
 * Students tutored for free (i.e. `FEE` = $0.00) will not be displayed.
 * If all students have paid their fees within the past month, no students will be displayed.

--- a/src/main/java/seedu/address/model/student/admin/PaymentDate.java
+++ b/src/main/java/seedu/address/model/student/admin/PaymentDate.java
@@ -3,9 +3,12 @@ package seedu.address.model.student.admin;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Represents the last time a Student paid his tuition fees.
@@ -13,14 +16,18 @@ import java.time.format.DateTimeParseException;
  */
 public class PaymentDate {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Payment dates should be valid and in the form dd/mm/yy, and should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Payment dates should be a valid date in the form dd/mm/yy, "
+            + "should not be blank, "
+            + "and should not be future-dated";
 
     private static final DateTimeFormatter INPUT_DEF = DateTimeFormatter.ofPattern("d/M/yy");
     private static final DateTimeFormatter INPUT_ALT = DateTimeFormatter.ofPattern("d/M/yyyy");
     private static final DateTimeFormatter OUTPUT = DateTimeFormatter.ofPattern("dd MMM yyyy");
 
     public static final String TODAY = LocalDate.now().format(INPUT_DEF);
+
+    private static final Pattern VALIDATION_REGEX =
+            Pattern.compile("(?<day>[0-9]{1,2})(/)(?<month>[0-9]{1,2})(/)(?<year>[0-9]{2}|[0-9]{4})");
 
     public final LocalDate lastPaid;
 
@@ -52,17 +59,29 @@ public class PaymentDate {
      * Returns true if a given string is in the correct date format.
      */
     public static boolean isValidDate(String test) {
-        LocalDate testDate = null;
-        for (DateTimeFormatter format : new DateTimeFormatter[] {INPUT_DEF, INPUT_ALT}) {
-            try {
-                testDate = LocalDate.parse(test, format);
-                break;
-            } catch (DateTimeParseException ignored) {
-                // does not match the DateTimeFormat, try the next
-            }
+        Matcher matcher = VALIDATION_REGEX.matcher(test);
+        if (!matcher.matches()) {
+            return false;
         }
 
-        return testDate != null;
+        String day = matcher.group("day");
+        String month = matcher.group("month");
+        String year = matcher.group("year");
+
+        if (year.length() < 4) {
+            year = "20" + year;
+        }
+
+        int parseDay = Integer.parseInt(day);
+        int parseMonth = Integer.parseInt(month);
+        int parseYear = Integer.parseInt(year);
+
+        try {
+            LocalDate date = LocalDate.of(parseYear, parseMonth, parseDay);
+            return date.compareTo(LocalDate.now()) <= 0;
+        } catch (DateTimeException e) {
+            return false;
+        }
     }
 
     public String convertPaymentDateToUserInputString() {

--- a/src/test/java/seedu/address/logic/commands/OverdueCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OverdueCommandTest.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.core.Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.model.student.admin.Fee.FREE_OF_CHARGE;
+import static seedu.address.testutil.StudentBuilder.DEFAULT_FEE;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.time.LocalDate;
@@ -22,7 +24,7 @@ public class OverdueCommandTest {
     private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("d/M/yy");
 
     @Test
-    public void execute() {
+    public void execute_positiveFee() {
         // one student with overdue fees
         int studentsWhoHaveNotPaid = 1;
         Model model = getDateAdjustedModel(studentsWhoHaveNotPaid);
@@ -49,6 +51,26 @@ public class OverdueCommandTest {
 
     }
 
+    @Test
+    public void execute_freeFee() {
+        int freeloaders = 0;
+        Model model = getFeeAdjustedModel(freeloaders);
+        int studentsWhoHaveNotPaid = model.getSortedStudentList().size() - freeloaders;
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, studentsWhoHaveNotPaid);
+        Model expectedModel = new ModelManager(model.getReeve(), new UserPrefs());
+        expectedModel.updateFilteredStudentList(new OverdueFeePredicate());
+        assertCommandSuccess(new OverdueCommand(), model, expectedMessage, expectedModel);
+
+        freeloaders = 3;
+        model = getFeeAdjustedModel(freeloaders);
+        studentsWhoHaveNotPaid = model.getSortedStudentList().size() - freeloaders;
+        expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, studentsWhoHaveNotPaid);
+        expectedModel = new ModelManager(model.getReeve(), new UserPrefs());
+        expectedModel.updateFilteredStudentList(new OverdueFeePredicate());
+        assertCommandSuccess(new OverdueCommand(), model, expectedMessage, expectedModel);
+
+    }
+
     /**
      * Returns a Model with {@code limit} number of students with overdue fees.
      */
@@ -67,6 +89,29 @@ public class OverdueCommandTest {
             reeve.setStudent(toReplace, replacement);
         }
         return new ModelManager(reeve, new UserPrefs());
+    }
+
+    /**
+     * Returns a Model with {@code limit} number of students with no fees.
+     */
+    private static Model getFeeAdjustedModel(int oneBasedLimit) {
+        Reeve reeve = getTypicalAddressBook();
+        int size = reeve.getStudentList().size();
+        String date = LocalDate.now().minusMonths(1).minusDays(1).format(FORMAT);
+
+        for (int i = 0; i < size; i++) {
+            Student toReplace = reeve.getStudentList().get(i);
+            String fee;
+            if (i < oneBasedLimit) {
+                fee = FREE_OF_CHARGE;
+            } else {
+                fee = DEFAULT_FEE;
+            }
+            Student replacement = new StudentBuilder(toReplace).withFee(fee).withPaymentDate(date).build();
+            reeve.setStudent(toReplace, replacement);
+        }
+        return new ModelManager(reeve, new UserPrefs());
+
     }
 
 }

--- a/src/test/java/seedu/address/model/student/admin/PaymentDateTest.java
+++ b/src/test/java/seedu/address/model/student/admin/PaymentDateTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
 public class PaymentDateTest {
@@ -22,21 +25,12 @@ public class PaymentDateTest {
     }
 
     @Test
-    public void isValidDate() {
-        // null date
+    public void isValidDate_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new PaymentDate(null));
+    }
 
-        // invalid date
-        assertFalse(PaymentDate.isValidDate(""));
-        assertFalse(PaymentDate.isValidDate("2-2-22"));
-        assertFalse(PaymentDate.isValidDate("2/2/2"));
-        assertFalse(PaymentDate.isValidDate("12.2.31"));
-        assertFalse(PaymentDate.isValidDate("abc"));
-        assertFalse(PaymentDate.isValidDate("32/10/19"));
-        assertFalse(PaymentDate.isValidDate("0/0/1021"));
-        assertFalse(PaymentDate.isValidDate("12/14/1021"));
-
-        // valid date
+    @Test
+    public void isValidDate_validValue_returnsTrue() {
         assertTrue(PaymentDate.isValidDate("12/12/12"));
         assertTrue(PaymentDate.isValidDate("12/2/12"));
         assertTrue(PaymentDate.isValidDate("2/12/12"));
@@ -45,5 +39,54 @@ public class PaymentDateTest {
         assertTrue(PaymentDate.isValidDate("12/2/2002"));
         assertTrue(PaymentDate.isValidDate("2/12/2002"));
         assertTrue(PaymentDate.isValidDate("2/2/2002"));
+    }
+
+    @Test
+    public void isValidDate_invalidFormat_returnsFalse() {
+        assertFalse(PaymentDate.isValidDate("")); // blank
+        assertFalse(PaymentDate.isValidDate("abc")); // not even a date
+        assertFalse(PaymentDate.isValidDate("2-2-22")); // - instead of / to delimit fields
+        assertFalse(PaymentDate.isValidDate("12.2.31")); // . instead of / to delimit fields
+        assertFalse(PaymentDate.isValidDate("2/2")); // missing at least one field
+
+        assertFalse(PaymentDate.isValidDate("2/2/2")); // year has too few characters
+        assertFalse(PaymentDate.isValidDate("2/2/020")); // year has 3 characters instead of 2/4
+        assertFalse(PaymentDate.isValidDate("2/2/22020")); // year has too many characters
+
+        assertFalse(PaymentDate.isValidDate("222/2/2")); // day has too few characters
+        assertFalse(PaymentDate.isValidDate("2/222/020")); // month has 3 characters instead of 2/4
+    }
+
+    @Test
+    public void isValidDate_invalidDate_returnsFalse() {
+        // invalid days
+        assertFalse(PaymentDate.isValidDate("31/11/19"));
+        assertFalse(PaymentDate.isValidDate("31/11/2019"));
+        assertFalse(PaymentDate.isValidDate("32/10/19"));
+        assertFalse(PaymentDate.isValidDate("32/10/2019"));
+        assertFalse(PaymentDate.isValidDate("29/2/19"));
+        assertFalse(PaymentDate.isValidDate("30/2/20"));
+
+        assertFalse(PaymentDate.isValidDate("0/10/19")); // too low
+        assertFalse(PaymentDate.isValidDate("0/10/2019"));
+
+        // invalid months
+        assertFalse(PaymentDate.isValidDate("20/0/19"));
+        assertFalse(PaymentDate.isValidDate("20/13/19"));
+        assertFalse(PaymentDate.isValidDate("20/0/2019"));
+        assertFalse(PaymentDate.isValidDate("20/13/2019"));
+    }
+
+    @Test
+    public void isValidDate_pastPresentFuture() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy");
+        String future = LocalDate.now().plusDays(1).format(formatter);
+        assertFalse(PaymentDate.isValidDate(future));
+
+        String present = LocalDate.now().format(formatter);
+        assertTrue(PaymentDate.isValidDate(present));
+
+        String past = LocalDate.now().minusDays(1).format(formatter);
+        assertTrue(PaymentDate.isValidDate(past));
     }
 }


### PR DESCRIPTION
* PaymentDate validation now checks if the `day` provided is valid for the `month` provided, and does not accept future dates.
* Incorrect command format in the user guide has been fixed.
* OverdueTest now includes tests to make sure that students of `fee = 0` are filtered out.

@VaishakAnand @hogantan might wanna refer to how `PaymentDate::isValidDate` is implemented since #177 has a suggestion for it.

Resolves #160, Resolves #176 