### PR TITLE
Keep filter criteria after edit

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -264,8 +264,6 @@ Format: `delete STUDENT_INDEX`
 
 :information_source: `STUDENT_INDEX` **must be a positive integer** 1, 2, 3, …​
 
-:information_source: You will need to use this if you wish to view the full student list after using commands such as `find`, `overdue` and `schedule`.
-
 </div>
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -280,14 +280,13 @@ Format: `sort COMPARISON_MEANS`
 
 * The valid options for the sorting method `COMPARISON_MEANS` are `name`, `classTime` or `year`.
 * Only one option for the sorting method can be specified.
-* The sorting method is case sensitive when being specified
-* Sorting methods:
+* Sorting methods (case sensitive):
 	* `name`: Sorts students by their name in alphabetical order. This is case insensitive.
-	* `classTime`: Sorts students by the the time of their class first by the day than the time.
-	* `year` Sorts students by the school year they are in with `Primary` type years coming before `Secondary` type coming before `JC` type.
+	* `classTime`: Sorts students by the day followed by time of their class.
+	* `year`: Sorts students by their school year, with `Primary` students coming before `Secondary` students followed by `JC` students.
 
 Examples:
-* `sort year` to sort students by their year
+* `sort year` to sort students by year of study.
 
 #### 3.3.7 Finding students with overdue fees: `overdue` (By: Ying Gao)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -197,6 +197,11 @@ Edits an existing student in **Reeve**.
 
 Format: `edit STUDENT_INDEX [n/NAME] [p/PHONE] [s/SCHOOL] [y/YEAR] [v/CLASS_VENUE] [t/CLASS_TIME] [f/FEE] [d/PAYMENT_DATE] `
 
+* Edits the student at the specified `STUDENT_INDEX`. The index refers to the index number shown in the displayed student list. The index **must be a positive integer** 1, 2, 3, …​
+* At least one of the optional fields must be provided.
+* Existing values will be updated to the input values.
+* Start time has to be before end time.
+
 <div markdown="block" class="alert alert-info">
 
 :information_source: The format of TIME is {int: Day_of_week} {int: Start_time}-{int: End_time}<br>
@@ -204,12 +209,12 @@ Day_of_week refers to an Integer value from 1 - 7, with 1, 3 and 7 representing 
 Start_time and End_time refer to time values in 24hr format (1200-1700)<br>
 E.g. "4 0900-1700" means a class time of Thursday, 9am to 5pm.
 
-</div>
+:information_source: If using this command after `find`, the edited student may no longer satisfy the search criteria depending on the field changed.
+In that case the student will be hidden from view and can be viewed again using `list` or `find`.<br>
+E.g. `edit 1 n/Amy Choo` after `find n/Bob` will cause the student to be hidden since her name no longer contains "Bob".
+You can use `list` or `find` (e.g `find n/Amy`) to display her information again. 
 
-* Edits the student at the specified `STUDENT_INDEX`. The index refers to the index number shown in the displayed student list. The index **must be a positive integer** 1, 2, 3, …​
-* At least one of the optional fields must be provided.
-* Existing values will be updated to the input values.
-* Start time has to be before end time.
+</div>
 
 Examples:
 *  `edit 1 n/Alex p/99999999 s/Meridian Junior College` Edits the name, phone number and school of the 1st student to be `Alex`, `99999999` and `Meridian Junior College` respectively.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -278,13 +278,14 @@ Format: `sort COMPARISON_MEANS`
 
 * The valid options for the sorting method `COMPARISON_MEANS` are `name`, `classTime` or `year`.
 * Only one option for the sorting method can be specified.
-* Sorting methods (case sensitive):
+* The sorting method is case sensitive when being specified
+* Sorting methods:
 	* `name`: Sorts students by their name in alphabetical order. This is case insensitive.
-	* `classTime`: Sorts students by the day followed by time of their class.
-	* `year`: Sorts students by their school year, with `Primary` students coming before `Secondary` students followed by `JC` students.
+	* `classTime`: Sorts students by the the time of their class first by the day than the time.
+	* `year` Sorts students by the school year they are in with `Primary` type years coming before `Secondary` type coming before `JC` type.
 
 Examples:
-* `sort year` to sort students by year of study.
+* `sort year` to sort students by their year
 
 #### 3.3.7 Finding students with overdue fees: `overdue` (By: Ying Gao)
 

--- a/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE_FEEDBACK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE_STATUS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -75,7 +74,6 @@ public class AddAttendanceCommand extends AttendanceCommand {
         Student updatedStudent = updateStudentAttendance(studentToAddAttendance, updatedAttendance);
 
         model.setStudent(studentToAddAttendance, updatedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, updatedStudent.getName(), attendanceToAdd));

--- a/src/main/java/seedu/address/logic/commands/AddDetailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDetailCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TEXT;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -71,7 +70,6 @@ public class AddDetailCommand extends DetailCommand {
         Student updatedStudent = super.updateStudentDetail(studentToAddDetail, details);
 
         model.setStudent(studentToAddDetail, updatedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
         return new CommandResult(String.format(MESSAGE_SUCCESS, updatedStudent.getName(), detailToAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/AddExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddExamCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXAM_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXAM_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCORE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +74,6 @@ public class AddExamCommand extends ExamCommand {
                 selectedStudent.getSchool(), selectedStudent.getYear(), selectedStudent.getAdmin(),
                 selectedStudent.getQuestions(), exams, selectedStudent.getAttendance());
         model.setStudent(selectedStudent, updatedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(String.format(MESSAGE_EXAM_ADDED_SUCCESS, updatedStudent.getName(), toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddQuestionCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -60,7 +59,6 @@ public class AddQuestionCommand extends QuestionCommand {
 
         Student replacement = asker.addQuestion(questionToAdd);
         model.setStudent(asker, replacement);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
         return new CommandResult(String.format(MESSAGE_SUCCESS, replacement.getName(), questionToAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE_DATE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -70,7 +69,6 @@ public class DeleteAttendanceCommand extends AttendanceCommand {
         Student updatedStudent = updateStudentAttendance(studentToDeleteAttendance, updatedAttendance);
 
         model.setStudent(studentToDeleteAttendance, updatedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, updatedStudent.getName(), getUserInputDateString()));

--- a/src/main/java/seedu/address/logic/commands/DeleteDetailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteDetailCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -77,7 +76,6 @@ public class DeleteDetailCommand extends DetailCommand {
         Student updatedStudent = super.updateStudentDetail(studentToAddDetail, details);
 
         model.setStudent(studentToAddDetail, updatedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
         return new CommandResult(String.format(MESSAGE_SUCCESS, updatedStudent.getName(), removedDetail));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteExamCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXAM_INDEX;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +68,6 @@ public class DeleteExamCommand extends ExamCommand {
         Student updatedStudent = super.updateStudentExam(studentToDeleteExam, exams);
 
         model.setStudent(studentToDeleteExam, updatedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(String.format(MESSAGE_EXAM_DELETED_SUCCESS, updatedStudent.getName(), removedExam));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteQuestionCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -60,7 +59,6 @@ public class DeleteQuestionCommand extends QuestionCommand {
         Student replacement = asker.deleteQuestion(deleted);
 
         model.setStudent(asker, replacement);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
         return new CommandResult(String.format(MESSAGE_SUCCESS, replacement.getName(), deleted));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHOOL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENUE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.Optional;
@@ -101,7 +100,6 @@ public class EditCommand extends Command {
         }
 
         model.setStudent(studentToEdit, editedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedStudent));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditDetailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditDetailCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TEXT;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -84,7 +83,6 @@ public class EditDetailCommand extends DetailCommand {
         Student updatedStudent = super.updateStudentDetail(studentToAddDetail, details);
 
         model.setStudent(studentToAddDetail, updatedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
         return new CommandResult(String.format(MESSAGE_SUCCESS, updatedStudent.getName(), detailToAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -62,7 +61,6 @@ public class SolveQuestionCommand extends QuestionCommand {
         Student replacement = asker.setQuestion(target, solved);
 
         model.setStudent(asker, replacement);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         logger.log(Level.INFO, "Execution complete");
         return new CommandResult(String.format(MESSAGE_SUCCESS, replacement.getName(), solved));
     }

--- a/src/test/java/seedu/address/logic/commands/AddAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAttendanceCommandTest.java
@@ -94,6 +94,7 @@ public class AddAttendanceCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), model.getNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/AddDetailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddDetailCommandTest.java
@@ -75,7 +75,7 @@ public class AddDetailCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_throwsCommandException() {
+    public void execute_validIndexFilteredList_success() {
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
 
         Student asker = model.getSortedStudentList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -91,6 +91,7 @@ public class AddDetailCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), getTypicalNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
@@ -100,6 +100,7 @@ public class AddExamCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), model.getNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/AddQuestionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddQuestionCommandTest.java
@@ -111,6 +111,7 @@ public class AddQuestionCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), getTypicalNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(addQuestionCommand, model, expectedMessage, expectedModel);
 

--- a/src/test/java/seedu/address/logic/commands/DeleteAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteAttendanceCommandTest.java
@@ -106,6 +106,7 @@ public class DeleteAttendanceCommandTest {
 
         ModelManager expectedModel = new ModelManager(newModel.getReeve(), new UserPrefs(), newModel.getNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(command, newModel, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteDetailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteDetailCommandTest.java
@@ -105,6 +105,7 @@ public class DeleteDetailCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), getTypicalNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
@@ -100,6 +100,7 @@ public class DeleteExamCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), model.getNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteQuestionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteQuestionCommandTest.java
@@ -93,6 +93,7 @@ public class DeleteQuestionCommandTest {
         Student expected = deleteQuestion(questionIndex, clone);
         Model expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), getTypicalNotebook());
         expectedModel.setStudent(clone, expected);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         DeleteQuestionCommand command = new DeleteQuestionCommand(INDEX_FIRST_PERSON, questionIndex);
         String expectedMessage = String.format(MESSAGE_SUCCESS, expected.getName(), removed);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_FEE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SCHOOL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -94,17 +95,17 @@ public class EditCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Student studentInSortedList = model.getSortedStudentList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Student editedStudent = new StudentBuilder(studentInSortedList).withName(VALID_NAME_BOB)
+        Student editedStudent = new StudentBuilder(studentInSortedList).withSchool(VALID_SCHOOL_BOB)
                 .withFee(VALID_FEE_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build(),
+                new EditStudentDescriptorBuilder().withSchool(VALID_SCHOOL_BOB).build(),
                 new EditAdminDescriptorBuilder().withFee(VALID_FEE_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedStudent);
 
         Model expectedModel = new ModelManager(new Reeve(model.getReeve()), new UserPrefs(), getTypicalNotebook());
-        expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
-
+        expectedModel.setStudent(studentInSortedList, editedStudent);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/EditDetailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditDetailCommandTest.java
@@ -121,6 +121,7 @@ public class EditDetailCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), getTypicalNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(editAdditionalDetailCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/SolveQuestionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SolveQuestionCommandTest.java
@@ -105,6 +105,7 @@ public class SolveQuestionCommandTest {
         SolveQuestionCommand solveCommand = new SolveQuestionCommand(INDEX_FIRST_PERSON, question, DEFAULT_SOLUTION);
         ModelManager expectedModel = new ModelManager(model.getReeve(), new UserPrefs(), model.getNotebook());
         expectedModel.setStudent(clone, expectedStudent);
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
 
         assertCommandSuccess(solveCommand, model, expectedMessage, expectedModel);
 


### PR DESCRIPTION
Rationale:
Previously the only commands you would use after `find` is `edit` and `delete`, both of which are single-stage commands after which you no longer need the find criteria.
However, tutors may have to modify details, questions or other stuff after just editing admin fields, so they should still be allowed to keep the field in order to continue doing their thing.

Resolves #192 