### PR TITLE
Tweaks to messages and strings

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -190,19 +190,16 @@ Format: `add n/NAME p/PHONE s/SCHOOL y/YEAR v/CLASS_VENUE t/CLASS_TIME [f/FEE] [
 
 * `FEE` defaults to $0.00 if not included.
 * `LAST_PAYMENT_DATE` defaults to today's date if not included.
-
 * The format of `CLASS_TIME` is as follows:
     * `DAY_OF_WEEK START_TIME-END_TIME`
-    * `DAY_OF_WEEK` is any number from 1 to 7, where 1 refers to Monday while 7 refers to Sunday.
-    * `START_TIME` and `END_TIME` follows the 24-hr clock format (e.g. 1pm refers to 1300).
-
+    * `DAY_OF_WEEK` is any integer from 1 to 7, where 1 refers to Monday while 7 refers to Sunday.
+    * `START_TIME` and `END_TIME` follows the 24-hr clock format (e.g. 1300 refers to 1pm).
 * The format of `LAST_PAYMENT_DATE` is as follows:
     * `d/m/yyyy or dd/mm/yyyy` (e.g. both 03/02/2020 and 3/2/2020 are acceptable).
-
 * The format of `YEAR` is as follows:
     * `TYPE_OF_SCHOOL LEVEL` (e.g. y/primary 2 and y/p 2 are the same and both acceptable).
-    * `TYPE_OF_SCHOOL` can be primary(pri, p), secondary(sec, s) or jc.
-    * `LEVEL` has to correspond with the `TYPE_OF_SCHOOL` (e.g. primary 1 - primary 6, secondary 1 - secondary 5, jc 1 - jc 2)
+    * `TYPE_OF_SCHOOL` accepts Primary (Pri/P), Secondary (Sec/S) or JC (J), and is case-insensitive.
+    * `LEVEL` has to be valid for the `TYPE_OF_SCHOOL` (i.e. Primary 1 - Primary 6, Secondary 1 - Secondary 5, JC 1 - JC 2)
 
 <div markdown="block" class="alert alert-info">
 
@@ -233,19 +230,15 @@ Format: `list`
 
 Edits an existing student in **Reeve**.
 
-Format: `edit STUDENT_INDEX [n/NAME] [p/PHONE] [s/SCHOOL] [y/YEAR] [v/CLASS_VENUE] [t/CLASS_TIME] [f/FEE] [d/PAYMENT_DATE] `
+Format: `edit STUDENT_INDEX [n/NAME] [p/PHONE] [s/SCHOOL] [y/YEAR] [v/CLASS_VENUE] [t/CLASS_TIME] [f/FEE] [d/LAST_PAYMENT_DATE] `
 
 * Edits the student at the specified `STUDENT_INDEX`. The index refers to the index number shown in the displayed student list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * Start time has to be before end time.
+* The format of `CLASS_TIME`, `YEAR` and `LAST_PAYMENT_DATE` follows that as stated in [3.3.1 Adding a student](#331-adding-a-student-add-by-hogan).
 
 <div markdown="block" class="alert alert-info">
-
-:information_source: The format of TIME is {int: Day_of_week} {int: Start_time}-{int: End_time}<br>
-Day_of_week refers to an Integer value from 1 - 7, with 1, 3 and 7 representing Monday, Wednesday and Sunday respectively.<br>
-Start_time and End_time refer to time values in 24hr format (1200-1700)<br>
-E.g. "4 0900-1700" means a class time of Thursday, 9am to 5pm.
 
 :information_source: If using this command after `find`, the edited student may no longer satisfy the search criteria depending on the field changed.
 In that case the student will be hidden from view and can be viewed again using `list` or `find`.<br>
@@ -270,11 +263,7 @@ Format: `find [n/NAME] [s/SCHOOL] [y/YEAR]`
 * For the school criteria, only students with a school that contains **all keywords** specified will be matched.
 * For the year criteria, only students with the **same year** will be matched. (See below for more elaboration for format of year)
 * Only students matching all criteria specified will be returned (i.e `AND` search).
-
-* The format of `YEAR` is as follows:
-    * `TYPE_OF_SCHOOL LEVEL` (e.g. y/primary 2 and y/p 2 are the same and both acceptable).
-    * `TYPE_OF_SCHOOL` can be primary(pri, p), secondary(sec, s) or jc. 
-    * `LEVEL` has to correspond with the `TYPE_OF_SCHOOL` (e.g. primary 1 - primary 6, secondary 1 - secondary 5, jc 1 - jc 2)
+* The format of `YEAR` follows that as stated in [3.3.1 Adding a student](#331-adding-a-student-add-by-hogan).
 
 Examples:
 * `find n/Alex david` matches `Alex David`, `alex david` and `Alex david`.

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,11 +7,10 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
+    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "There is no student at the given index!";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
-    public static final String MESSAGE_UNKNOWN_DETAIL_COMMAND = "Unknown detail command";
     public static final String MESSAGE_CLASHING_LESSON = "You have another lesson that clashes with this lesson!";
-    public static final String MESSAGE_STUDENTS_SORTED = "Students sorted by %s";
+    public static final String MESSAGE_STUDENTS_SORTED = "Students sorted by %1%s!";
 
-    public static final String MESSAGE_INVALID_NOTE_DISPLAYED_INDEX = "The note index provided is invalid";
+    public static final String MESSAGE_INVALID_NOTE_DISPLAYED_INDEX = "There is no note at the given index!";
 }

--- a/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
@@ -21,10 +21,10 @@ public class AddAttendanceCommand extends AttendanceCommand {
 
     public static final String COMMAND_WORD = "add";
     public static final String MESSAGE_USAGE = AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD
-            + ": adds an attendance record to the specified student.\n"
+            + ": adds an attendance record to the specified student.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ATTENDANCE_DATE + "LESSON_DATE " + PREFIX_ATTENDANCE_STATUS + "ATTENDANCE_STATUS "
-            + "[" + PREFIX_ATTENDANCE_FEEDBACK + "FEEDBACK]\n"
+            + "[" + PREFIX_ATTENDANCE_FEEDBACK + "FEEDBACK]\n\n"
             + "Example: " + AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD + " 2 "
             + PREFIX_ATTENDANCE_DATE + "14/02/2020 " + PREFIX_ATTENDANCE_STATUS + "present "
             + PREFIX_ATTENDANCE_FEEDBACK + "attentive";

--- a/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
@@ -21,7 +21,7 @@ public class AddAttendanceCommand extends AttendanceCommand {
 
     public static final String COMMAND_WORD = "add";
     public static final String MESSAGE_USAGE = AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD
-            + ": adds an attendance record to the specified student.\n\n"
+            + ": Adds an attendance record to the specified student.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ATTENDANCE_DATE + "LESSON_DATE " + PREFIX_ATTENDANCE_STATUS + "ATTENDANCE_STATUS "
             + "[" + PREFIX_ATTENDANCE_FEEDBACK + "FEEDBACK]\n\n"

--- a/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAttendanceCommand.java
@@ -21,9 +21,8 @@ public class AddAttendanceCommand extends AttendanceCommand {
 
     public static final String COMMAND_WORD = "add";
     public static final String MESSAGE_USAGE = AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD
-            + ": adds an Attendance to the student identified "
-            + "by the index number used in the displayed student list. \n"
-            + "Parameters: STUDENT_INDEX (must be a positive integer) "
+            + ": adds an attendance record to the specified student.\n"
+            + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ATTENDANCE_DATE + "LESSON_DATE " + PREFIX_ATTENDANCE_STATUS + "ATTENDANCE_STATUS "
             + "[" + PREFIX_ATTENDANCE_FEEDBACK + "FEEDBACK]\n"
             + "Example: " + AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD + " 2 "

--- a/src/main/java/seedu/address/logic/commands/AddQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddQuestionCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TEXT;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -22,6 +23,14 @@ public class AddQuestionCommand extends QuestionCommand {
     public static final String MESSAGE_SUCCESS = "New question added to student %1$s: %2$s";
     public static final String MESSAGE_DUPLICATE_QUESTION = "This student has already asked this question";
     public static final String COMMAND_WORD = "add";
+
+    public static final String MESSAGE_USAGE = QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD
+            + ": Adds a new unresolved question to a student.\n\n"
+            + "PARAMETERS: INDEX (must be a positive integer) "
+            + PREFIX_TEXT + "QUESTION_TEXT\n\n"
+            + "Example: "
+            + QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD
+            + " 1 " + PREFIX_TEXT + "How do birds fly?";
 
     private static Logger logger = Logger.getLogger("Add Question Log");
 

--- a/src/main/java/seedu/address/logic/commands/AddQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddQuestionCommand.java
@@ -26,7 +26,7 @@ public class AddQuestionCommand extends QuestionCommand {
 
     public static final String MESSAGE_USAGE = QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Adds a new unresolved question to a student.\n\n"
-            + "PARAMETERS: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_TEXT + "QUESTION_TEXT\n\n"
             + "Example: "
             + QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD

--- a/src/main/java/seedu/address/logic/commands/AttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendanceCommand.java
@@ -8,8 +8,9 @@ import seedu.address.model.student.academic.Attendance;
 public abstract class AttendanceCommand extends Command {
 
     public static final String COMMAND_WORD = "attendance";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds or deletes an Attendance from a student in "
-             + " Reeve. \n" + "SUPPORTED COMMANDS: add, delete";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds or deletes an attendance record "
+            + "from a student in Reeve.\n\n"
+            + "SUPPORTED COMMANDS: add, delete";
 
     /**
      * Creates a new Student, with the provided attendance.

--- a/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
@@ -22,7 +22,7 @@ public class DeleteAttendanceCommand extends AttendanceCommand {
 
     public static final String COMMAND_WORD = "delete";
     public static final String MESSAGE_USAGE = AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD
-            + ": deletes the attendance record from the specified student "
+            + ": Deletes the attendance record from the specified student "
             + "matching the given lesson date. \n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ATTENDANCE_DATE + "LESSON_DATE\n\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
@@ -23,9 +23,9 @@ public class DeleteAttendanceCommand extends AttendanceCommand {
     public static final String COMMAND_WORD = "delete";
     public static final String MESSAGE_USAGE = AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": deletes the attendance record from the specified student "
-            + "matching the given lesson date. \n"
+            + "matching the given lesson date. \n\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_ATTENDANCE_DATE + "LESSON_DATE\n"
+            + PREFIX_ATTENDANCE_DATE + "LESSON_DATE\n\n"
             + "Example: " + AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD + " 2 "
             + PREFIX_ATTENDANCE_DATE + "14/02/2020";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAttendanceCommand.java
@@ -22,9 +22,9 @@ public class DeleteAttendanceCommand extends AttendanceCommand {
 
     public static final String COMMAND_WORD = "delete";
     public static final String MESSAGE_USAGE = AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD
-            + ": deletes an Attendance from the student identified "
-            + "by the date of the lesson. \n"
-            + "Parameters: STUDENT_INDEX (must be a positive integer) "
+            + ": deletes the attendance record from the specified student "
+            + "matching the given lesson date. \n"
+            + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ATTENDANCE_DATE + "LESSON_DATE\n"
             + "Example: " + AttendanceCommand.COMMAND_WORD + " " + COMMAND_WORD + " 2 "
             + PREFIX_ATTENDANCE_DATE + "14/02/2020";

--- a/src/main/java/seedu/address/logic/commands/DeleteQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteQuestionCommand.java
@@ -26,7 +26,7 @@ public class DeleteQuestionCommand extends QuestionCommand {
 
     public static final String MESSAGE_USAGE = QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Deletes a question from a student.\n\n"
-            + "PARAMETERS: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_INDEX + "QUESTION_INDEX\n\n"
             + "Example: "
             + QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1 " + PREFIX_INDEX + "1";

--- a/src/main/java/seedu/address/logic/commands/DeleteQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteQuestionCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -22,6 +23,13 @@ public class DeleteQuestionCommand extends QuestionCommand {
     public static final String MESSAGE_SUCCESS = "Question removed from %1$s: %2$s";
     public static final String MESSAGE_BAD_QUESTION_INDEX = "There is no question at this index";
     public static final String COMMAND_WORD = "delete";
+
+    public static final String MESSAGE_USAGE = QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD
+            + ": Deletes a question from a student.\n\n"
+            + "PARAMETERS: INDEX (must be a positive integer) "
+            + PREFIX_INDEX + "QUESTION_INDEX\n\n"
+            + "Example: "
+            + QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1 " + PREFIX_INDEX + "1";
 
     private static Logger logger = Logger.getLogger("Delete Question Log");
 

--- a/src/main/java/seedu/address/logic/commands/ExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExamCommand.java
@@ -1,10 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EXAM_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EXAM_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EXAM_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SCORE;
-
 import java.util.ArrayList;
 
 import seedu.address.model.student.Student;
@@ -19,21 +14,7 @@ public abstract class ExamCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds, deletes an exam "
             + "or view exam statistics of student "
             + "to/from a student in Reeve.\n\n"
-            + "Example:\n"
-            + "To add an exam:\n"
-            + ExamCommand.COMMAND_WORD
-            + " add" + " 1 "
-            + PREFIX_EXAM_NAME
-            + " End of Year Examination 2020 "
-            + PREFIX_EXAM_DATE + "7/11/2020 "
-            + PREFIX_SCORE + "50/100 \n(adds an exam to the first student in the list)\n\n"
-            + "To delete an exam:\n"
-            + ExamCommand.COMMAND_WORD
-            + " delete" + " 2 "
-            + PREFIX_EXAM_INDEX + "1 \n(deletes the first exam of the second student in the list)\n\n"
-            + "To view a student's exam statistics:\n"
-            + ExamCommand.COMMAND_WORD
-            + " stats" + " 1 \n(view statistics of first student in the list)";
+            + "SUPPORTED COMMANDS: add, delete, stats";
 
     /**
      * Updates a specific students exam list when an exam is being added or deleted.

--- a/src/main/java/seedu/address/logic/commands/ExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExamCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.student.academic.exam.Exam;
 public abstract class ExamCommand extends Command {
     public static final String COMMAND_WORD = "exam";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds/deletes an exam "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds, deletes an exam "
             + "or view exam statistics of student "
             + "to/from a student in Reeve.\n\n"
             + "Example:\n"

--- a/src/main/java/seedu/address/logic/commands/QuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/QuestionCommand.java
@@ -1,8 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TEXT;
-
 public abstract class QuestionCommand extends Command {
 
     public static final String COMMAND_WORD = "question";
@@ -11,12 +8,5 @@ public abstract class QuestionCommand extends Command {
             + "from a student in Reeve.\n\n"
             + "Example:\n"
             + "To add a new question:\n"
-            + COMMAND_WORD + " add 1 " + PREFIX_TEXT + "How do birds fly?\n"
-            + "(adds a new question to the first student on the list)\n\n"
-            + "To resolve a question:\n"
-            + COMMAND_WORD + " solve 1 " + PREFIX_INDEX + "1 " + PREFIX_TEXT + "They don't.\n"
-            + "(solves the first question from the first student on the list)\n\n"
-            + "To delete a question:\n"
-            + COMMAND_WORD + " delete 1 " + PREFIX_INDEX + "1\n"
-            + "(deletes the first question from the first student on the list)";
+            + "SUPPORTED COMMANDS: add, solve, delete";
 }

--- a/src/main/java/seedu/address/logic/commands/QuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/QuestionCommand.java
@@ -6,7 +6,5 @@ public abstract class QuestionCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds, resolves or deletes a question "
             + "from a student in Reeve.\n\n"
-            + "Example:\n"
-            + "To add a new question:\n"
             + "SUPPORTED COMMANDS: add, solve, delete";
 }

--- a/src/main/java/seedu/address/logic/commands/QuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/QuestionCommand.java
@@ -8,14 +8,15 @@ public abstract class QuestionCommand extends Command {
     public static final String COMMAND_WORD = "question";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds, resolves or deletes a question "
-            + "from a student in Reeve. "
-            + "Supported actions: \n"
-            + "add INDEX " + PREFIX_TEXT + "QUESTION: adds an unresolved question.\n"
-            + "Example: " + COMMAND_WORD + " add 1 " + PREFIX_TEXT + "How do birds fly\n"
-            + "solve INDEX " + PREFIX_INDEX + "QUESTION_INDEX "
-            + PREFIX_TEXT + "SOLUTION: marks a question as solved.\n"
-            + "Example: " + COMMAND_WORD + " solve 1 " + PREFIX_INDEX + " 1 "
-            + PREFIX_TEXT + "Read your textbook.\n"
-            + "delete INDEX " + PREFIX_INDEX + "QUESTION_INDEX: deletes a question.\n"
-            + "Example: " + COMMAND_WORD + " delete 2 " + PREFIX_INDEX + " 1 \n";
+            + "from a student in Reeve.\n\n"
+            + "Example:\n"
+            + "To add a new question:\n"
+            + COMMAND_WORD + " add 1 " + PREFIX_TEXT + "How do birds fly?\n"
+            + "(adds a new question to the first student on the list)\n\n"
+            + "To resolve a question:\n"
+            + COMMAND_WORD + " solve 1 " + PREFIX_INDEX + "1 " + PREFIX_TEXT + "They don't.\n"
+            + "(solves the first question from the first student on the list)\n\n"
+            + "To delete a question:\n"
+            + COMMAND_WORD + " delete 1 " + PREFIX_INDEX + "1\n"
+            + "(deletes the first question from the first student on the list)";
 }

--- a/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TEXT;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -24,6 +26,15 @@ public class SolveQuestionCommand extends QuestionCommand {
     public static final String MESSAGE_SOLVED_QUESTION = "This question was already solved";
     public static final String MESSAGE_BAD_QUESTION_INDEX = "There is no question at this index";
     public static final String COMMAND_WORD = "solve";
+
+    public static final String MESSAGE_USAGE = QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD
+            + ": Resolves a question from a student.\n\n"
+            + "PARAMETERS: INDEX (must be a positive integer) "
+            + PREFIX_INDEX + "QUESTION_INDEX "
+            + PREFIX_TEXT + "QUESTION_TEXT\n\n"
+            + "Example: "
+            + QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1 "
+            + PREFIX_INDEX + "1 " + PREFIX_TEXT + "They don't.";
 
     private static Logger logger = Logger.getLogger("Solve Question Log");
 

--- a/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
@@ -34,7 +34,7 @@ public class SolveQuestionCommand extends QuestionCommand {
             + PREFIX_TEXT + "QUESTION_TEXT\n\n"
             + "Example: "
             + QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1 "
-            + PREFIX_INDEX + "1 " + PREFIX_TEXT + "They don't.";
+            + PREFIX_INDEX + "1 " + PREFIX_TEXT + "Read your textbook.";
 
     private static Logger logger = Logger.getLogger("Solve Question Log");
 

--- a/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SolveQuestionCommand.java
@@ -29,7 +29,7 @@ public class SolveQuestionCommand extends QuestionCommand {
 
     public static final String MESSAGE_USAGE = QuestionCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Resolves a question from a student.\n\n"
-            + "PARAMETERS: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_INDEX + "QUESTION_INDEX "
             + PREFIX_TEXT + "QUESTION_TEXT\n\n"
             + "Example: "

--- a/src/main/java/seedu/address/logic/commands/notes/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/notes/AddNoteCommand.java
@@ -16,7 +16,9 @@ public class AddNoteCommand extends NoteCommand {
             + ": Adds a note to the notebook.\n\n"
             + "Parameters: "
             + PREFIX_TITLE + "TITLE "
-            + PREFIX_DESCRIPTION + "DESCRIPTION ";
+            + PREFIX_DESCRIPTION + "DESCRIPTION\n\n"
+            + "Example: " + NoteCommand.COMMAND_WORD + " " + COMMAND_WORD + " "
+            + PREFIX_TITLE + "Grade assignment " + PREFIX_DESCRIPTION + "Do by tonight";
 
 
     public static final String MESSAGE_SUCCESS = "New note added:\n%1$s";

--- a/src/main/java/seedu/address/logic/commands/notes/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/notes/DeleteNoteCommand.java
@@ -19,9 +19,9 @@ public class DeleteNoteCommand extends NoteCommand {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = NoteCommand.COMMAND_WORD + " " + COMMAND_WORD
-            + ": Deletes the note identified by the index number used in the displayed notebook.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the note identified by the index number used in the displayed notebook.\n\n"
+            + "Parameters: INDEX (must be a positive integer)\n\n"
+            + "Example: " + NoteCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted Note: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/notes/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/notes/EditNoteCommand.java
@@ -25,12 +25,14 @@ public class EditNoteCommand extends NoteCommand {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = NoteCommand.COMMAND_WORD + " " + COMMAND_WORD
-            + ": Edits the details of the note identified "
-            + "by the index number used in the displayed notebook. "
-            + "Existing values will be overwritten by the input values.\n"
+            + ": Edits the details of the note at the specified index. "
+            + "Existing values will be overwritten by the input values.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TITLE + "TITLE] "
-            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] ";
+            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION]\n\n"
+            + "Example: "
+            + NoteCommand.COMMAND_WORD + " " + COMMAND_WORD + " "
+            + PREFIX_TITLE + "Another title " + PREFIX_DESCRIPTION + "Another description";
 
     public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edited Note:\n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/notes/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/notes/NoteCommand.java
@@ -8,5 +8,8 @@ import seedu.address.logic.commands.Command;
 public abstract class NoteCommand extends Command {
 
     public static final String COMMAND_WORD = "note";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds, edits or deletes a note "
+            + "in Reeve.\n\n"
+            + "SUPPORTED COMMANDS: add, edit, delete";
 
 }

--- a/src/main/java/seedu/address/logic/parser/QuestionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/QuestionCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.QuestionCommand.MESSAGE_USAGE;
 import static seedu.address.logic.parser.CliSyntax.COMMAND_PREFIXES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TEXT;
@@ -23,6 +22,15 @@ import seedu.address.model.student.academic.question.UnsolvedQuestion;
  */
 public class QuestionCommandParser extends PrefixDependentParser<QuestionCommand> {
 
+    private static final String MESSAGE_INVALID_COMMAND =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, QuestionCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_ADD_COMMAND =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddQuestionCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_SOLVE_COMMAND =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, SolveQuestionCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_DEL_COMMAND =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteQuestionCommand.MESSAGE_USAGE);
+
     /**
      * Parses the given {@code String} in the context of a QuestionCommand
      * and returns a QuestionCommand for execution.
@@ -35,8 +43,7 @@ public class QuestionCommandParser extends PrefixDependentParser<QuestionCommand
 
         Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_USAGE));
+            throw new ParseException(MESSAGE_INVALID_COMMAND);
         }
 
         String commandWord = matcher.group("commandWord");
@@ -54,23 +61,7 @@ public class QuestionCommandParser extends PrefixDependentParser<QuestionCommand
             return parseSolveQuestionCommand(arguments);
 
         default:
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
-        }
-    }
-
-    private Index getStudentIndex(ArgumentMultimap argumentMultimap) throws ParseException {
-        try {
-            return ParserUtil.parseIndex(argumentMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE), pe);
-        }
-    }
-
-    private Index getQuestionIndex(ArgumentMultimap argumentMultimap) throws ParseException {
-        try {
-            return ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_INDEX).get());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE), pe);
+            throw new ParseException(MESSAGE_INVALID_COMMAND);
         }
     }
 
@@ -81,10 +72,16 @@ public class QuestionCommandParser extends PrefixDependentParser<QuestionCommand
                 ArgumentTokenizer.tokenize(input, PREFIX_TEXT);
 
         if (!areRequiredPrefixesPresent(argMultimap, PREFIX_TEXT)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+            throw new ParseException(MESSAGE_INVALID_ADD_COMMAND);
         }
 
-        Index studentIndex = getStudentIndex(argMultimap);
+        Index studentIndex;
+        try {
+            studentIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(MESSAGE_INVALID_ADD_COMMAND, pe);
+        }
+
         UnsolvedQuestion questionToAdd = ParserUtil.parseQuestion(argMultimap.getValue(PREFIX_TEXT).get());
 
         return new AddQuestionCommand(studentIndex, questionToAdd);
@@ -95,13 +92,19 @@ public class QuestionCommandParser extends PrefixDependentParser<QuestionCommand
                 ArgumentTokenizer.tokenize(input, COMMAND_PREFIXES);
 
         if (!areRequiredPrefixesPresent(argMultimap, COMMAND_PREFIXES)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+            throw new ParseException(MESSAGE_INVALID_SOLVE_COMMAND);
         }
 
-        Index studentIndex = getStudentIndex(argMultimap);
-        Index questionIndex = getQuestionIndex(argMultimap);
-        String solution = ParserUtil.parseSolution(argMultimap.getValue(PREFIX_TEXT).get());
+        Index studentIndex;
+        Index questionIndex;
+        try {
+            studentIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            questionIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+        } catch (ParseException pe) {
+            throw new ParseException(MESSAGE_INVALID_SOLVE_COMMAND, pe);
+        }
 
+        String solution = ParserUtil.parseSolution(argMultimap.getValue(PREFIX_TEXT).get());
         return new SolveQuestionCommand(studentIndex, questionIndex, solution);
     }
 
@@ -110,11 +113,17 @@ public class QuestionCommandParser extends PrefixDependentParser<QuestionCommand
                 ArgumentTokenizer.tokenize(input, PREFIX_INDEX);
 
         if (!areRequiredPrefixesPresent(argMultimap, PREFIX_INDEX)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+            throw new ParseException(MESSAGE_INVALID_DEL_COMMAND);
         }
 
-        Index studentIndex = getStudentIndex(argMultimap);
-        Index questionIndex = getQuestionIndex(argMultimap);
+        Index studentIndex;
+        Index questionIndex;
+        try {
+            studentIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            questionIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+        } catch (ParseException pe) {
+            throw new ParseException(MESSAGE_INVALID_DEL_COMMAND, pe);
+        }
 
         return new DeleteQuestionCommand(studentIndex, questionIndex);
     }

--- a/src/main/java/seedu/address/logic/parser/notes/NotebookParser.java
+++ b/src/main/java/seedu/address/logic/parser/notes/NotebookParser.java
@@ -32,7 +32,7 @@ public class NotebookParser implements Parser<NoteCommand> {
     public NoteCommand parse(String userInput) throws ParseException {
         final Matcher matcher = BASIC_NOTE_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("noteCommandWord");
@@ -50,7 +50,7 @@ public class NotebookParser implements Parser<NoteCommand> {
             return new DeleteNoteCommandParser().parse(arguments);
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE));
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/notes/NotebookParser.java
+++ b/src/main/java/seedu/address/logic/parser/notes/NotebookParser.java
@@ -1,12 +1,10 @@
 package seedu.address.logic.parser.notes;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.notes.AddNoteCommand;
 import seedu.address.logic.commands.notes.DeleteNoteCommand;
 import seedu.address.logic.commands.notes.EditNoteCommand;

--- a/src/main/java/seedu/address/model/student/academic/Attendance.java
+++ b/src/main/java/seedu/address/model/student/academic/Attendance.java
@@ -80,8 +80,8 @@ public class Attendance {
 
     @Override
     public String toString() {
-        String feedback = getFeedback().map(Feedback::toString).orElse("");
-        return String.format("%1$s (%2$s) %3$s",
+        String feedback = getFeedback().map(fdb -> String.format("[%1$s]", fdb)).orElse("");
+        return String.format("(%2$s) %1$s %3$s",
                 print(lessonDate), (isStudentPresent() ? "\u2713" : "\u2718"), feedback);
     }
 

--- a/src/main/java/seedu/address/model/student/admin/ClassTime.java
+++ b/src/main/java/seedu/address/model/student/admin/ClassTime.java
@@ -16,8 +16,11 @@ import java.util.Objects;
  */
 public class ClassTime implements Comparable<ClassTime> {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Class Time should follow the following format: {int: day_of_week} {int: start_time}-{int: end_time}";
+    public static final String MESSAGE_CONSTRAINTS = "Class Time should follow the following format:\n"
+            + "DAY_OF_WEEK START_TIME-END_TIME (no space between time fields)\n"
+            + "DAY_OF_WEEK: Integer (positive) from 1-7 representing Mon-Sun\n"
+            + "START_TIME/END_TIME: Time in 24hr clock\n"
+            + "e.g 1 1200-1300: Monday, 12pm to 1pm";
     public static final String TIME_CONSTRAINTS = "End time should always be after Start time";
 
     /*

--- a/src/test/java/seedu/address/logic/parser/QuestionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/QuestionCommandParserTest.java
@@ -25,6 +25,12 @@ public class QuestionCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, QuestionCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_ADD_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddQuestionCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_SOLVE_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, SolveQuestionCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_DEL_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteQuestionCommand.MESSAGE_USAGE);
 
     private static final String ADD_QUESTION_DESC = AddQuestionCommand.COMMAND_WORD + " ";
     private static final String SOLVE_QUESTION_DESC = SolveQuestionCommand.COMMAND_WORD + " ";
@@ -44,24 +50,24 @@ public class QuestionCommandParserTest {
     @Test
     public void parse_addQuestionMissingParts_failure() {
         // missing student index
-        assertParseFailure(parser, ADD_QUESTION_DESC + QUESTION_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ADD_QUESTION_DESC + QUESTION_DESC_AMY, MESSAGE_INVALID_ADD_FORMAT);
 
         // missing student question
-        assertParseFailure(parser, ADD_QUESTION_DESC + "1", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ADD_QUESTION_DESC + "1", MESSAGE_INVALID_ADD_FORMAT);
     }
 
     @Test
     public void parse_addQuestionInvalidPreamble_failure() {
         // invalid integers
-        assertParseFailure(parser, ADD_QUESTION_DESC + "0" + QUESTION_DESC_AMY, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, ADD_QUESTION_DESC + "-2" + QUESTION_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ADD_QUESTION_DESC + "0" + QUESTION_DESC_AMY, MESSAGE_INVALID_ADD_FORMAT);
+        assertParseFailure(parser, ADD_QUESTION_DESC + "-2" + QUESTION_DESC_AMY, MESSAGE_INVALID_ADD_FORMAT);
 
         // invalid argument
-        assertParseFailure(parser, ADD_QUESTION_DESC + "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ADD_QUESTION_DESC + "1 some random string", MESSAGE_INVALID_ADD_FORMAT);
 
         // invalid prefix parsed as preamble
         String invalidPrefix = " " + PREFIX_INDEX + VALID_QUESTION_AMY;
-        assertParseFailure(parser, ADD_QUESTION_DESC + "1" + invalidPrefix, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ADD_QUESTION_DESC + "1" + invalidPrefix, MESSAGE_INVALID_ADD_FORMAT);
     }
 
     @Test
@@ -85,40 +91,40 @@ public class QuestionCommandParserTest {
     public void parse_solveQuestionMissingParts_failure() {
         // missing student index
         assertParseFailure(parser, SOLVE_QUESTION_DESC + QUESTION_INDEX_DESC + SOLUTION_DESC,
-                MESSAGE_INVALID_FORMAT);
+                MESSAGE_INVALID_SOLVE_FORMAT);
 
         // missing question question
-        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + SOLUTION_DESC, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + SOLUTION_DESC, MESSAGE_INVALID_SOLVE_FORMAT);
 
         // missing solution
-        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + QUESTION_INDEX_DESC, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + QUESTION_INDEX_DESC, MESSAGE_INVALID_SOLVE_FORMAT);
     }
 
     @Test
     public void parse_solveQuestionInvalidPreamble_failure() {
         // invalid integers
         assertParseFailure(parser, SOLVE_QUESTION_DESC + "0" + QUESTION_INDEX_DESC + SOLUTION_DESC,
-                MESSAGE_INVALID_FORMAT);
+                MESSAGE_INVALID_SOLVE_FORMAT);
         assertParseFailure(parser, SOLVE_QUESTION_DESC + "-2" + QUESTION_INDEX_DESC + SOLUTION_DESC,
-                MESSAGE_INVALID_FORMAT);
+                MESSAGE_INVALID_SOLVE_FORMAT);
 
         // invalid argument
-        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1 some random string", MESSAGE_INVALID_SOLVE_FORMAT);
 
         // invalid prefix parsed as preamble
         String invalidPrefix = "1 p/ string";
-        assertParseFailure(parser, SOLVE_QUESTION_DESC + invalidPrefix, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, SOLVE_QUESTION_DESC + invalidPrefix, MESSAGE_INVALID_SOLVE_FORMAT);
     }
 
     @Test
     public void parse_solveQuestionInvalidQuestionIndex_failure() {
         // negative index
         String invalidIndex = " " + PREFIX_INDEX + "-5";
-        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + invalidIndex, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + invalidIndex, MESSAGE_INVALID_SOLVE_FORMAT);
 
         // 0 index
         invalidIndex = " " + PREFIX_INDEX + "0";
-        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + invalidIndex, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, SOLVE_QUESTION_DESC + "1" + invalidIndex, MESSAGE_INVALID_SOLVE_FORMAT);
     }
 
     @Test
@@ -146,36 +152,36 @@ public class QuestionCommandParserTest {
     @Test
     public void parse_deleteQuestionMissingParts_failure() {
         // missing student index
-        assertParseFailure(parser, DEL_QUESTION_DESC + QUESTION_INDEX_DESC, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + QUESTION_INDEX_DESC, MESSAGE_INVALID_DEL_FORMAT);
 
         // missing question index
-        assertParseFailure(parser, DEL_QUESTION_DESC + "1", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "1", MESSAGE_INVALID_DEL_FORMAT);
     }
 
     @Test
     public void parse_deleteQuestionInvalidPreamble_failure() {
         // invalid integers
-        assertParseFailure(parser, DEL_QUESTION_DESC + "0" + QUESTION_INDEX_DESC, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, DEL_QUESTION_DESC + "-2" + QUESTION_INDEX_DESC, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "0" + QUESTION_INDEX_DESC, MESSAGE_INVALID_DEL_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "-2" + QUESTION_INDEX_DESC, MESSAGE_INVALID_DEL_FORMAT);
 
         // invalid argument
-        assertParseFailure(parser, DEL_QUESTION_DESC + "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "1 some random string", MESSAGE_INVALID_DEL_FORMAT);
 
         // invalid prefix parsed as preamble
         String invalidPrefix = " " + PREFIX_TEXT + "string";
-        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidPrefix, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidPrefix, MESSAGE_INVALID_DEL_FORMAT);
     }
 
     @Test
     public void parse_deleteQuestionInvalidArgument_failure() {
         String invalidQuestion = " " + PREFIX_INDEX + "-1";
-        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidQuestion, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidQuestion, MESSAGE_INVALID_DEL_FORMAT);
 
         invalidQuestion = " " + PREFIX_INDEX + "0";
-        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidQuestion, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidQuestion, MESSAGE_INVALID_DEL_FORMAT);
 
         invalidQuestion = " " + PREFIX_INDEX + " ";
-        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidQuestion, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, DEL_QUESTION_DESC + "1" + invalidQuestion, MESSAGE_INVALID_DEL_FORMAT);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/academic/AttendanceTest.java
+++ b/src/test/java/seedu/address/model/student/academic/AttendanceTest.java
@@ -74,18 +74,20 @@ public class AttendanceTest {
     @Test
     public void toString_feedbackTest() {
         String outputDate = print(VALID_DATE);
-        String expected = outputDate + " (\u2713) " + FEEDBACK_INPUT;
+        String outputDateDesc = outputDate + " ";
+        String feedbackDesc = "[" + FEEDBACK_INPUT + "]";
+        String expected = "(\u2713) " + outputDateDesc + feedbackDesc;
         assertEquals(expected, VALID_ATTENDANCE.toString());
 
-        expected = outputDate + " (\u2718) " + FEEDBACK_INPUT;
+        expected = "(\u2718) " + outputDateDesc + feedbackDesc;
         Attendance test = new Attendance(VALID_DATE, false, VALID_FEEDBACK);
         assertEquals(expected, test.toString());
 
-        expected = outputDate + " (\u2713) ";
+        expected = "(\u2713) " + outputDateDesc;
         test = new Attendance(VALID_DATE, true);
         assertEquals(expected, test.toString());
 
-        expected = outputDate + " (\u2718) ";
+        expected = "(\u2718) " + outputDateDesc;
         test = new Attendance(VALID_DATE, false);
         assertEquals(expected, test.toString());
     }


### PR DESCRIPTION
* Standardised note/attendance/exam/question command messages (Resolves #246)
* Attendance format now follows question's format (`(PRESENCE) DATE [FEEDBACK]`)
* Tweak class time constraint message (Resolves #235)
* Improve out of bounds index message (Resolves #236) - "there is no student at the given index"